### PR TITLE
fix: skip account selection on repeated login by reusing Google session

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -151,6 +151,7 @@ function App() {
     },
     onError: (errorResponse) => console.log("Login failed! Error:", errorResponse),
     scope: "https://www.googleapis.com/auth/drive.readonly",
+    prompt: '', // 既存のGoogleセッションを使用（アカウント選択画面をスキップ）
   });
 
   // ログアウト処理


### PR DESCRIPTION
## Summary
- Google認証時にアカウント選択画面をスキップ
- 既存のGoogleセッションを再利用して、UXを改善

## Changes
- `useGoogleLogin` に `prompt: ''` パラメータを追加
- これにより、ユーザーが既にGoogleにログインしている場合、アカウント選択画面なしで自動的に認証される
- アカウント選択は初回ログイン時またはセッション期限切れ時のみ表示される

## Test plan
- [ ] 初回ログイン時にアカウント選択画面が表示されることを確認
- [ ] 2回目以降のログイン時にアカウント選択画面がスキップされることを確認
- [ ] Googleからログアウト後、再度アカウント選択が表示されることを確認

## Impact
リピートユーザーのログイン体験が向上し、認証プロセスの摩擦が軽減されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)