### PR TITLE
feat: sort folder dropdown by most recently added

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -110,10 +110,21 @@ function App() {
 
   // 新しいフォルダが追加されたときのハンドラ
   const handleAddFolder = (newFolder: FolderOption) => {
-    setFolderOptions((prevOptions: Array<{ id: string; name: string }>) => [
-      ...prevOptions,
-      newFolder,
-    ]);
+    setFolderOptions((prevOptions: FolderOption[]) => {
+      // "all" フォルダと通常フォルダを分離
+      const allFolder = prevOptions.find((f) => f.id === "all");
+      const otherFolders = prevOptions.filter((f) => f.id !== "all");
+
+      // 新しいフォルダを追加してaddedTimeでソート（降順：新しいものが先頭）
+      const updatedFolders = [...otherFolders, newFolder].sort((a, b) => {
+        const timeA = a.addedTime ?? 0;
+        const timeB = b.addedTime ?? 0;
+        return timeB - timeA;
+      });
+
+      // "all" フォルダを先頭に戻す
+      return allFolder ? [allFolder, ...updatedFolders] : updatedFolders;
+    });
   };
 
   const handleDeleteFolder = (folderId: string) => {

--- a/src/components/FolderManagement.tsx
+++ b/src/components/FolderManagement.tsx
@@ -75,7 +75,7 @@ const FolderManagement: React.FC<FolderManagementProps> = ({
 
   const handleAdd = () => {
     if (folderId && folderName) {
-      onAddFolder({ id: folderId, name: folderName });
+      onAddFolder({ id: folderId, name: folderName, addedTime: Date.now() });
       setFolderId("");
       setFolderName("");
       onClose();

--- a/src/components/FolderSettingsModal.tsx
+++ b/src/components/FolderSettingsModal.tsx
@@ -29,7 +29,13 @@ const FolderSettingsModal: React.FC<FolderSettingsModalProps> = ({
     onClose();
   };
 
-  const registeredFolders = folders.filter((f) => f.id !== "all");
+  const registeredFolders = folders
+    .filter((f) => f.id !== "all")
+    .sort((a, b) => {
+      const timeA = a.addedTime ?? 0;
+      const timeB = b.addedTime ?? 0;
+      return timeB - timeA; // 降順：新しいものが先頭
+    });
  
   return (
     <>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,6 +9,7 @@ export interface DriveFile {
 export interface FolderOption {
   id: string;
   name: string;
+  addedTime?: number;
 }
 
 export interface FolderManagementProps {


### PR DESCRIPTION
## Summary
- Issue #8 の実装: プルダウンの中を一番最近追加したものを上にする

## Changes
- `FolderOption` インターフェースに `addedTime` フィールドを追加（タイムスタンプ記録用）
- `FolderManagement` コンポーネントで新規フォルダ追加時にタイムスタンプを付与
- `App.tsx` の `handleAddFolder` を更新して `addedTime` の降順でソート
- `FolderSettingsModal` でフォルダを最近追加順に表示
- "すべてのフォルダ" オプションは常に先頭に表示

## Implementation Details

### 変更ファイル
1. **src/types/index.ts** - `FolderOption` に `addedTime?: number` を追加
2. **src/components/FolderManagement.tsx** - フォルダ追加時に `Date.now()` でタイムスタンプを設定
3. **src/App.tsx** - フォルダを `addedTime` でソート（降順：新しいものが先頭）
4. **src/components/FolderSettingsModal.tsx** - 設定画面でもフォルダを最近追加順に表示

### 表示順序
```
1. すべてのフォルダ（常に先頭）
2. フォルダC（最新）
3. フォルダB
4. フォルダA（最も古い）
```

### 後方互換性
- `addedTime` がない既存フォルダは `0` として扱われ、リストの最後に表示されます
- 既存のlocalStorageデータにも対応

## Test plan
- [x] TypeScript型チェック通過
- [x] ビルド成功（Vite + PWA）
- [x] "すべてのフォルダ" が常に先頭に表示されることを確認
- [x] 新規フォルダが追加されたときにリストの先頭（"すべて" の次）に表示されることを確認

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)