### PR TITLE
fix: sort folders by latest music file date instead of folder added time

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback, lazy, Suspense } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo, lazy, Suspense } from "react";
 // MUI コンポーネントを個別インポート（バンドルサイズ最適化）
 import AppBar from "@mui/material/AppBar";
 import Box from "@mui/material/Box";
@@ -108,23 +108,41 @@ function App() {
   const [undoFolder, setUndoFolder] = useState<FolderOption | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
+  // フォルダを曲の最新更新日時でソート
+  const sortedFolderOptions = useMemo(() => {
+    if (!allFetchedMusicFiles || allFetchedMusicFiles.length === 0) {
+      return folderOptions;
+    }
+
+    // 各フォルダの最新曲の日時を計算
+    const folderLatestTimes = new Map<string, number>();
+    for (const file of allFetchedMusicFiles) {
+      const modifiedTime = new Date(file.modifiedTime).getTime();
+      for (const parentId of file.parents) {
+        const currentLatest = folderLatestTimes.get(parentId) || 0;
+        if (modifiedTime > currentLatest) {
+          folderLatestTimes.set(parentId, modifiedTime);
+        }
+      }
+    }
+
+    // "all" フォルダを分離
+    const allFolder = folderOptions.find((f) => f.id === "all");
+    const otherFolders = folderOptions.filter((f) => f.id !== "all");
+
+    // 他のフォルダを最新曲の日時でソート（降順：新しいものが先頭）
+    const sorted = otherFolders.sort((a, b) => {
+      const timeA = folderLatestTimes.get(a.id) || 0;
+      const timeB = folderLatestTimes.get(b.id) || 0;
+      return timeB - timeA;
+    });
+
+    return allFolder ? [allFolder, ...sorted] : sorted;
+  }, [folderOptions, allFetchedMusicFiles]);
+
   // 新しいフォルダが追加されたときのハンドラ
   const handleAddFolder = (newFolder: FolderOption) => {
-    setFolderOptions((prevOptions: FolderOption[]) => {
-      // "all" フォルダと通常フォルダを分離
-      const allFolder = prevOptions.find((f) => f.id === "all");
-      const otherFolders = prevOptions.filter((f) => f.id !== "all");
-
-      // 新しいフォルダを追加してaddedTimeでソート（降順：新しいものが先頭）
-      const updatedFolders = [...otherFolders, newFolder].sort((a, b) => {
-        const timeA = a.addedTime ?? 0;
-        const timeB = b.addedTime ?? 0;
-        return timeB - timeA;
-      });
-
-      // "all" フォルダを先頭に戻す
-      return allFolder ? [allFolder, ...updatedFolders] : updatedFolders;
-    });
+    setFolderOptions((prevOptions: FolderOption[]) => [...prevOptions, newFolder]);
   };
 
   const handleDeleteFolder = (folderId: string) => {
@@ -484,7 +502,7 @@ function App() {
                     },
                   }}
                 >
-                  {folderOptions.map((option: FolderOption) => (
+                  {sortedFolderOptions.map((option: FolderOption) => (
                     <MenuItem key={option.id} value={option.id}>
                       {option.name}
                     </MenuItem>
@@ -560,7 +578,7 @@ function App() {
           <FolderSettingsModal
             open={openFolderSettings}
             onClose={() => setOpenFolderSettings(false)}
-            folders={folderOptions}
+            folders={sortedFolderOptions}
             onDeleteFolder={handleDeleteFolder}
             onResetFolders={handleResetFolders}
           />

--- a/src/components/FolderManagement.tsx
+++ b/src/components/FolderManagement.tsx
@@ -75,7 +75,7 @@ const FolderManagement: React.FC<FolderManagementProps> = ({
 
   const handleAdd = () => {
     if (folderId && folderName) {
-      onAddFolder({ id: folderId, name: folderName, addedTime: Date.now() });
+      onAddFolder({ id: folderId, name: folderName });
       setFolderId("");
       setFolderName("");
       onClose();

--- a/src/components/FolderSettingsModal.tsx
+++ b/src/components/FolderSettingsModal.tsx
@@ -29,13 +29,7 @@ const FolderSettingsModal: React.FC<FolderSettingsModalProps> = ({
     onClose();
   };
 
-  const registeredFolders = folders
-    .filter((f) => f.id !== "all")
-    .sort((a, b) => {
-      const timeA = a.addedTime ?? 0;
-      const timeB = b.addedTime ?? 0;
-      return timeB - timeA; // 降順：新しいものが先頭
-    });
+  const registeredFolders = folders.filter((f) => f.id !== "all");
  
   return (
     <>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,7 +9,6 @@ export interface DriveFile {
 export interface FolderOption {
   id: string;
   name: string;
-  addedTime?: number;
 }
 
 export interface FolderManagementProps {


### PR DESCRIPTION
## Summary
- Issue #8 の修正: フォルダ追加日時ではなく、フォルダ内の曲の最新更新日時でソート

## Problem
PR #11 では、フォルダを追加した日時（`addedTime`）でソートしていましたが、ユーザーの期待は**フォルダ内の曲の最新更新日（`modifiedTime`）**でソートすることでした。

音楽プレイヤーの文脈では、「最近追加したもの」は「最近追加された曲が入っているフォルダ」という意味の方が自然です。

## Solution
- `FolderOption` から `addedTime` フィールドを削除
- `useMemo` を使って、各フォルダ内の最新曲の `modifiedTime` を計算
- その最新日時でフォルダをソート（降順：新しいものが先頭）

## Changes
1. **src/types/index.ts** - `addedTime` フィールドを削除
2. **src/App.tsx** 
   - `useMemo` で `sortedFolderOptions` を計算
   - 各フォルダの最新曲の `modifiedTime` でソート
   - `handleAddFolder` を簡略化（ソートは `useMemo` で処理）
3. **src/components/FolderManagement.tsx** - `addedTime` の設定を削除
4. **src/components/FolderSettingsModal.tsx** - 既にソート済みのデータを受け取るため、ソートロジックを削除

## Implementation Details

### ソートロジック
```tsx
const sortedFolderOptions = useMemo(() => {
  // 各フォルダの最新曲の日時を計算
  const folderLatestTimes = new Map<string, number>();
  for (const file of allFetchedMusicFiles) {
    const modifiedTime = new Date(file.modifiedTime).getTime();
    for (const parentId of file.parents) {
      const currentLatest = folderLatestTimes.get(parentId) || 0;
      if (modifiedTime > currentLatest) {
        folderLatestTimes.set(parentId, modifiedTime);
      }
    }
  }
  
  // フォルダを最新曲の日時でソート
  const sorted = otherFolders.sort((a, b) => {
    const timeA = folderLatestTimes.get(a.id) || 0;
    const timeB = folderLatestTimes.get(b.id) || 0;
    return timeB - timeA; // 降順
  });
  
  return allFolder ? [allFolder, ...sorted] : sorted;
}, [folderOptions, allFetchedMusicFiles]);
```

### 表示順序
```
1. すべてのフォルダ（常に先頭）
2. フォルダC（最新曲: 2026-03-20）
3. フォルダB（最新曲: 2026-03-15）
4. フォルダA（最新曲: 2026-03-01）
```

## Benefits
- より直感的なソート順序
- 最近更新された音楽が入っているフォルダがすぐに見つかる
- 音楽プレイヤーとしての UX 向上

## Test plan
- [x] TypeScript型チェック通過
- [x] ビルド成功（Vite + PWA）
- [x] 曲データが読み込まれたときに動的にソートされることを確認
- [x] "すべてのフォルダ" が常に先頭に表示されることを確認

Fixes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)