### PR TITLE
fix: add safe area inset for PWA header to prevent overlap

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -425,7 +425,7 @@ function App() {
       <CssBaseline />
       {/* アプリケーションのヘッダー部分 */}
       <AppBar position="static">
-        <Toolbar sx={{ gap: 2, mt: 0, mb: 0 }}>
+        <Toolbar sx={{ gap: 2, mt: 0, mb: 0, pt: 'env(safe-area-inset-top)' }}>
           <MusicNoteIcon sx={{ mr: 2 }} />
           <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
             GD-Player


### PR DESCRIPTION
## Summary
- Added `env(safe-area-inset-top)` padding to AppBar Toolbar to fix header overlap in iOS PWA
- Prevents header from being hidden behind status bar and notch on devices with notches

## Changes
- Modified `src/App.tsx` to add `pt: 'env(safe-area-inset-top)'` to Toolbar sx prop

## Problem
In PWA mode on iOS devices with notches (iPhone X and later), the header was being
partially hidden behind the status bar, making it difficult to see the app title and
logout button.

## Solution
Added safe area inset top padding using CSS environment variable `env(safe-area-inset-top)`.
This ensures the header respects the device's safe area and displays properly below the
status bar/notch.

## Test plan
- [x] TypeScript compilation successful
- [x] Vite build successful
- [ ] Test on iOS PWA with notch device

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)