### PR TITLE
feat: add client-side caching to reduce API calls

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ import { useGoogleLogin } from "@react-oauth/google";
 import { CustomAudioPlayer } from "./components/CustomAudioPlayer.tsx";
 import { MusicListSkeleton, TrackSwitchingIndicator, RetroLoadingSpinner } from "./components/SkeletonScreen.tsx";
 import { type DriveFile, type FolderOption } from "./types";
+import { getCachedMusicFiles, cacheMusicFiles } from "./utils/cache";
 import { ALL_FOLDERS_OPTION, LOCAL_STORAGE_KEYS } from "./constants";
 import { generateShareLink, copyToClipboard } from "./utils";
 
@@ -270,6 +271,16 @@ function App() {
       const failedFolders: string[] = [];
       for (const folder of foldersToFetch) {
         console.log(`[fetchMusicFiles] Fetching files from folder: ${folder.name} (${folder.id})`);
+
+        // まずキャッシュをチェック
+        const cachedFiles = getCachedMusicFiles(folder.id);
+        if (cachedFiles) {
+          console.log(`[fetchMusicFiles] Using cached data for ${folder.name} (${cachedFiles.length} files)`);
+          allFiles.push(...cachedFiles);
+          continue; // キャッシュがあればAPIコールをスキップ
+        }
+
+        // キャッシュがない場合はAPIコール
         try {
           const response = await axios.get("https://www.googleapis.com/drive/v3/files", {
             headers: {
@@ -282,8 +293,13 @@ function App() {
               includeItemsFromAllDrives: true,
             },
           });
-          console.log(`[fetchMusicFiles] Fetched ${response.data.files?.length || 0} files from ${folder.name}`);
-          allFiles.push(...(response.data.files || [])); // 取得したファイルをリストに追加
+          const fetchedFiles = response.data.files || [];
+          console.log(`[fetchMusicFiles] Fetched ${fetchedFiles.length} files from ${folder.name}`);
+
+          // 取得したデータをキャッシュに保存（10分間有効）
+          cacheMusicFiles(folder.id, fetchedFiles);
+
+          allFiles.push(...fetchedFiles); // 取得したファイルをリストに追加
         } catch (folderError: unknown) {
           if (axios.isAxiosError(folderError) && folderError.response?.status === 401) {
             // 認証エラーはすぐにログアウト

--- a/src/components/FolderManagement.tsx
+++ b/src/components/FolderManagement.tsx
@@ -9,6 +9,7 @@ import Button from "@mui/material/Button";
 import CircularProgress from "@mui/material/CircularProgress";
 import axios from "axios";
 import { type FolderManagementProps } from "../types";
+import { getCachedFolderMetadata, cacheFolderMetadata } from "../utils/cache";
 
 /**
  * フォルダ管理モーダルコンポーネント。
@@ -39,6 +40,22 @@ const FolderManagement: React.FC<FolderManagementProps> = ({
       if (folderId && accessToken) {
         setLoading(true);
         setError(null);
+
+        // まずキャッシュをチェック
+        const cachedMetadata = getCachedFolderMetadata(folderId);
+        if (cachedMetadata) {
+          console.log(`[FolderManagement] Using cached metadata for folder: ${folderId}`);
+          if (cachedMetadata.mimeType === "application/vnd.google-apps.folder") {
+            setFolderName(cachedMetadata.name);
+          } else {
+            setError("The provided ID is not a folder ID.");
+            setFolderName("");
+          }
+          setLoading(false);
+          return;
+        }
+
+        // キャッシュがない場合はAPIコール
         try {
           const response = await axios.get(
             `https://www.googleapis.com/drive/v3/files/${folderId}`,
@@ -52,6 +69,13 @@ const FolderManagement: React.FC<FolderManagementProps> = ({
               },
             },
           );
+
+          // 取得したデータをキャッシュに保存（30分間有効）
+          cacheFolderMetadata(folderId, {
+            name: response.data.name,
+            mimeType: response.data.mimeType,
+          });
+
           if (response.data.mimeType === "application/vnd.google-apps.folder") {
             setFolderName(response.data.name);
           } else {

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,0 +1,169 @@
+import type { DriveFile } from "../types";
+
+interface CacheEntry<T> {
+  data: T;
+  timestamp: number;
+  ttl: number; // Time to live in milliseconds
+}
+
+const CACHE_PREFIX = "music_player_cache_";
+
+/**
+ * キャッシュユーティリティクラス
+ * localStorageを使用してデータを時間制限付きでキャッシュ
+ */
+export class CacheManager {
+  /**
+   * データをキャッシュに保存
+   * @param key キャッシュキー
+   * @param data 保存するデータ
+   * @param ttl Time To Live（ミリ秒）、デフォルトは5分
+   */
+  static set<T>(key: string, data: T, ttl: number = 5 * 60 * 1000): void {
+    const entry: CacheEntry<T> = {
+      data,
+      timestamp: Date.now(),
+      ttl,
+    };
+
+    try {
+      localStorage.setItem(
+        `${CACHE_PREFIX}${key}`,
+        JSON.stringify(entry)
+      );
+    } catch (error) {
+      console.warn("キャッシュの保存に失敗しました:", error);
+    }
+  }
+
+  /**
+   * キャッシュからデータを取得
+   * @param key キャッシュキー
+   * @returns キャッシュされたデータ、または null（有効期限切れ/存在しない場合）
+   */
+  static get<T>(key: string): T | null {
+    try {
+      const item = localStorage.getItem(`${CACHE_PREFIX}${key}`);
+      if (!item) return null;
+
+      const entry: CacheEntry<T> = JSON.parse(item);
+      const now = Date.now();
+
+      // TTLチェック: 有効期限が切れていたら削除してnullを返す
+      if (now - entry.timestamp > entry.ttl) {
+        this.delete(key);
+        return null;
+      }
+
+      return entry.data;
+    } catch (error) {
+      console.warn("キャッシュの読み取りに失敗しました:", error);
+      return null;
+    }
+  }
+
+  /**
+   * 特定のキャッシュを削除
+   * @param key キャッシュキー
+   */
+  static delete(key: string): void {
+    try {
+      localStorage.removeItem(`${CACHE_PREFIX}${key}`);
+    } catch (error) {
+      console.warn("キャッシュの削除に失敗しました:", error);
+    }
+  }
+
+  /**
+   * すべてのキャッシュをクリア
+   */
+  static clear(): void {
+    try {
+      const keys = Object.keys(localStorage);
+      keys.forEach((key) => {
+        if (key.startsWith(CACHE_PREFIX)) {
+          localStorage.removeItem(key);
+        }
+      });
+    } catch (error) {
+      console.warn("キャッシュのクリアに失敗しました:", error);
+    }
+  }
+
+  /**
+   * キャッシュが存在するかチェック（有効期限も考慮）
+   * @param key キャッシュキー
+   * @returns キャッシュが有効な場合 true
+   */
+  static has(key: string): boolean {
+    return this.get(key) !== null;
+  }
+}
+
+/**
+ * 音楽ファイルリスト専用のキャッシュキーを生成
+ * @param folderId フォルダID
+ * @returns キャッシュキー
+ */
+export function getMusicFilesCacheKey(folderId: string): string {
+  return `music_files_${folderId}`;
+}
+
+/**
+ * フォルダメタデータ専用のキャッシュキーを生成
+ * @param folderId フォルダID
+ * @returns キャッシュキー
+ */
+export function getFolderMetadataCacheKey(folderId: string): string {
+  return `folder_metadata_${folderId}`;
+}
+
+/**
+ * 音楽ファイルリストをキャッシュ
+ * @param folderId フォルダID
+ * @param files ファイルリスト
+ * @param ttl Time To Live（デフォルト: 10分）
+ */
+export function cacheMusicFiles(
+  folderId: string,
+  files: DriveFile[],
+  ttl: number = 10 * 60 * 1000
+): void {
+  CacheManager.set(getMusicFilesCacheKey(folderId), files, ttl);
+}
+
+/**
+ * キャッシュされた音楽ファイルリストを取得
+ * @param folderId フォルダID
+ * @returns キャッシュされたファイルリスト、または null
+ */
+export function getCachedMusicFiles(folderId: string): DriveFile[] | null {
+  return CacheManager.get<DriveFile[]>(getMusicFilesCacheKey(folderId));
+}
+
+/**
+ * フォルダメタデータをキャッシュ
+ * @param folderId フォルダID
+ * @param metadata メタデータ（name, mimeType等）
+ * @param ttl Time To Live（デフォルト: 30分）
+ */
+export function cacheFolderMetadata(
+  folderId: string,
+  metadata: { name: string; mimeType: string },
+  ttl: number = 30 * 60 * 1000
+): void {
+  CacheManager.set(getFolderMetadataCacheKey(folderId), metadata, ttl);
+}
+
+/**
+ * キャッシュされたフォルダメタデータを取得
+ * @param folderId フォルダID
+ * @returns キャッシュされたメタデータ、または null
+ */
+export function getCachedFolderMetadata(
+  folderId: string
+): { name: string; mimeType: string } | null {
+  return CacheManager.get<{ name: string; mimeType: string }>(
+    getFolderMetadataCacheKey(folderId)
+  );
+}


### PR DESCRIPTION
## Summary

Issue #21 の実装: クライアント側でキャッシュして通信を減らす

Google Drive APIの呼び出しを削減するために、localStorage ベースの TTL 付きキャッシュシステムを実装しました。

## Changes

### 新規追加
- `src/utils/cache.ts`: キャッシュマネージャーユーティリティクラス
  - TTL（Time To Live）サポート
  - localStorage を使用した永続化
  - 型安全なキャッシュ操作

### 変更されたファイル
- `src/App.tsx`: 音楽ファイルリスト取得にキャッシュを追加
  - API コール前にキャッシュをチェック
  - キャッシュヒット時は API コールをスキップ
  - 取得したデータを 10 分間キャッシュ

- `src/components/FolderManagement.tsx`: フォルダメタデータ取得にキャッシュを追加
  - フォルダ名と MIME タイプをキャッシュ
  - 30 分間の有効期限

## Benefits

- **API 呼び出し削減**: ページリロードやフォルダ切り替え時の冗長なリクエストを削減
- **パフォーマンス向上**: キャッシュヒット時の応答速度が大幅に向上
- **帯域幅削減**: 不要なデータ転送を削減
- **API クォータ対策**: Google Drive API の利用制限を考慮
- **ユーザー体験向上**: より高速で快適な操作感

## Test Plan

- [x] 型チェック通過 (`npx tsc --noEmit`)
- [x] Vite ビルド成功
- [x] 既存機能に影響なし
- [x] キャッシュの有効期限が正しく動作することを確認
- [x] API コールがキャッシュにより削減されることをコンソールログで確認

## Implementation Details

### キャッシュ戦略
- **音楽ファイルリスト**: 10 分間有効（頻繁に変更されにくいため）
- **フォルダメタデータ**: 30 分間有効（ほとんど変更されないため）
- **自動無効化**: TTL 経過後は自動的にキャッシュを削除して最新データを取得

### 今後の拡張性
- IndexedDB を使用した Blob キャッシュ（音楽ファイル本体）の追加が可能
- キャッシュサイズの制限機能の追加が可能
- キャッシュクリア機能の UI 実装が可能

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)