### PR TITLE
fix: improve drag precision for bottom sheet player

### DIFF
--- a/src/components/CustomAudioPlayer.tsx
+++ b/src/components/CustomAudioPlayer.tsx
@@ -133,12 +133,22 @@ export const CustomAudioPlayer: React.FC<CustomAudioPlayerProps> = ({
     return `${minutes}:${seconds.toString().padStart(2, '0')}`;
   };
 
-  const handleDragEnd = (_event: MouseEvent | TouchEvent | PointerEvent, info: { offset: { y: number } }) => {
-    const threshold = 100;
-    if (info.offset.y < -threshold) {
+  const handleDrag = (_event: MouseEvent | TouchEvent | PointerEvent, info: { offset: { y: number } }) => {
+    setDragY(info.offset.y);
+  };
+
+  const handleDragEnd = (_event: MouseEvent | TouchEvent | PointerEvent, info: { offset: { y: number }; velocity: { y: number } }) => {
+    const threshold = 150;
+    const velocityThreshold = 500;
+
+    // velocity（速度）も考慮してスワイプを判定
+    const shouldExpand = info.offset.y < -threshold || info.velocity.y < -velocityThreshold;
+    const shouldCollapse = info.offset.y > threshold || info.velocity.y > velocityThreshold;
+
+    if (shouldExpand && !isExpanded) {
       setIsExpanded(true);
       setDragY(0);
-    } else if (info.offset.y > threshold) {
+    } else if (shouldCollapse && isExpanded) {
       setIsExpanded(false);
       setDragY(0);
     } else {
@@ -156,8 +166,11 @@ export const CustomAudioPlayer: React.FC<CustomAudioPlayerProps> = ({
     <Box
       component={motion.div}
       drag="y"
-      dragConstraints={{ top: 0, bottom: 0 }}
-      dragElastic={0.2}
+      dragConstraints={{ top: -200, bottom: 200 }}
+      dragElastic={0.5}
+      dragMomentum={false}
+      dragDirectionLock
+      onDrag={handleDrag}
       onDragEnd={handleDragEnd}
       initial={{ opacity: 0, y: 50 }}
       animate={{


### PR DESCRIPTION
## Summary
- Improved drag precision for the bottom sheet player to address Issue #26

## Changes
1. **Relaxed drag constraints**: Changed from `{top: 0, bottom: 0}` to `{top: -200, bottom: 200}` for better responsiveness
2. **Increased drag elasticity**: From `0.2` to `0.5` for smoother feel
3. **Added real-time position tracking**: Implemented `onDrag` handler to update `dragY` state during drag
4. **Added velocity-based swipe detection**: Threshold of 500px/s for faster gesture recognition
5. **Increased offset threshold**: From 100px to 150px for more intentional swipes
6. **Disabled drag momentum**: Added `dragMomentum={false}` to prevent unwanted slide after release
7. **Locked drag direction**: Added `dragDirectionLock` to ensure vertical-only dragging
8. **Improved expand/collapse logic**: Now considers both offset distance and velocity

## Technical Details
- Modified `src/components/CustomAudioPlayer.tsx`
- Enhanced framer-motion drag configuration
- Better UX with velocity-based gesture detection

## Test Plan
- [x] Type check passed (`npx tsc --noEmit`)
- [ ] Manual testing: Drag the player footer up/down with various speeds
- [ ] Test on mobile devices for touch responsiveness
- [ ] Verify smooth transitions between collapsed and expanded states

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)