### PR TITLE
fix: redesign toast notifications with retro-futuristic style

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1012,6 +1012,53 @@ function App() {
         autoHideDuration={4000}
         onClose={handleSnackbarClose}
         message={snackbarMessage}
+        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+        sx={{
+          top: 'calc(64px + env(safe-area-inset-top)) !important',
+          zIndex: 1300,
+        }}
+        ContentProps={{
+          sx: {
+            minWidth: '300px',
+            background: 'linear-gradient(135deg, rgba(255, 0, 110, 0.95), rgba(255, 77, 159, 0.95))',
+            backdropFilter: 'blur(10px)',
+            border: '2px solid',
+            borderImage: 'linear-gradient(90deg, #ff006e, #00f5d4) 1',
+            borderRadius: '12px',
+            boxShadow: '0 0 30px rgba(255, 0, 110, 0.6), 0 8px 32px rgba(0, 0, 0, 0.4)',
+            color: '#fff',
+            fontWeight: 600,
+            fontSize: '1rem',
+            fontFamily: 'Inter, sans-serif',
+            '& .MuiSnackbarContent-message': {
+              flex: 1,
+              textAlign: 'center',
+              textShadow: '0 2px 10px rgba(0, 0, 0, 0.3)',
+            },
+            '& .MuiSnackbarContent-action': {
+              marginRight: 0,
+              paddingLeft: '16px',
+              '& .MuiButton-root': {
+                color: '#fbf8cc',
+                fontWeight: 700,
+                textShadow: '0 0 10px rgba(251, 248, 204, 0.8)',
+                '&:hover': {
+                  background: 'rgba(251, 248, 204, 0.1)',
+                  transform: 'scale(1.05)',
+                },
+                transition: 'all 0.3s ease',
+              },
+              '& .MuiIconButton-root': {
+                color: '#fff',
+                '&:hover': {
+                  background: 'rgba(255, 255, 255, 0.1)',
+                  transform: 'rotate(90deg) scale(1.1)',
+                },
+                transition: 'all 0.3s ease',
+              },
+            },
+          },
+        }}
         action={
           <>
             {undoFolder && (


### PR DESCRIPTION
## Summary
- Redesigned toast notifications (Snackbar) to match the retro-futuristic theme and fix visibility issues

## Problem
- Toast notifications were hidden behind the player footer
- Design was too plain and didn't match the app's aesthetic
- Not optimized for PWA with notches

## Changes

### 1. Position & Visibility
- **Moved position**: Changed from bottom to top-center
- **Z-index**: Increased to 1300 (above player footer's 1100)
- **Safe area**: Added `calc(64px + env(safe-area-inset-top))` for PWA notch support

### 2. Retro-Futuristic Design
- **Background**: Gradient from pink (#ff006e) to light pink (#ff4d9f) with 95% opacity
- **Border**: 2px gradient border (pink to cyan)
- **Effects**: 
  - Glassmorphism with `backdrop-filter: blur(10px)`
  - Neon glow shadow: `0 0 30px rgba(255, 0, 110, 0.6)`
  - Border radius: 12px for modern look

### 3. Typography & Layout
- **Font**: Inter font family for consistency
- **Text**: Centered alignment with text shadow
- **Weight**: 600 for better readability
- **Min-width**: 300px for proper spacing

### 4. Interactive Elements
- **Undo button**: 
  - Bright yellow (#fbf8cc) color
  - Scale animation on hover (1.05x)
  - Neon text shadow effect
- **Close icon**:
  - Rotation animation on hover (90deg)
  - Scale animation (1.1x)
  - Smooth transitions

## Technical Details
- Modified `src/App.tsx` (Snackbar component)
- Uses MUI's `ContentProps` for custom styling
- All animations use CSS transitions for smooth effects

## Test Plan
- [x] Type check passed
- [ ] Test folder deletion with "元に戻す" button
- [ ] Test share link copy notification
- [ ] Verify visibility on mobile devices
- [ ] Test on devices with notches (PWA)
- [ ] Verify animations work smoothly

## Screenshots
Before: Plain white toast hidden behind player
After: Retro-futuristic toast at top with neon effects

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)