### PR TITLE
fix: remove border gaps and focus outline from toast notifications

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1022,8 +1022,7 @@ function App() {
             minWidth: '300px',
             background: 'linear-gradient(135deg, rgba(255, 0, 110, 0.95), rgba(255, 77, 159, 0.95))',
             backdropFilter: 'blur(10px)',
-            border: '2px solid',
-            borderImage: 'linear-gradient(90deg, #ff006e, #00f5d4) 1',
+            border: '2px solid #ff006e',
             borderRadius: '12px',
             boxShadow: '0 0 30px rgba(255, 0, 110, 0.6), 0 8px 32px rgba(0, 0, 0, 0.4)',
             color: '#fff',
@@ -1046,6 +1045,9 @@ function App() {
                   background: 'rgba(251, 248, 204, 0.1)',
                   transform: 'scale(1.05)',
                 },
+                '&:focus': {
+                  outline: 'none',
+                },
                 transition: 'all 0.3s ease',
               },
               '& .MuiIconButton-root': {
@@ -1053,6 +1055,9 @@ function App() {
                 '&:hover': {
                   background: 'rgba(255, 255, 255, 0.1)',
                   transform: 'rotate(90deg) scale(1.1)',
+                },
+                '&:focus': {
+                  outline: 'none',
                 },
                 transition: 'all 0.3s ease',
               },


### PR DESCRIPTION
## Summary
- Fixed visual issues with toast (Snackbar) notifications reported in Issue #30

## Changes
1. **Border rendering fix**: Replaced `borderImage` with solid border
   - `borderImage` is incompatible with `borderRadius`, causing gaps at corners
   - Changed to `border: '2px solid #ff006e'` for clean, rounded corners
   
2. **Focus outline removal**: Removed focus rings from toast action buttons
   - Added `'&:focus': { outline: 'none' }` to Button and IconButton styles
   - Improves visual consistency with retro-futuristic design theme

## Test plan
- [x] Type check passed (`npx tsc --noEmit`)
- [x] Visual verification: Toast corners now render cleanly without gaps
- [x] Focus behavior: No focus rings appear on toast buttons

## Before/After
- Before: Toast had visible gaps at corners due to borderImage/borderRadius conflict
- After: Toast renders with clean, rounded corners and no focus outlines

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)