### PR TITLE
fix: prevent bottom margin during drag by restricting drag constraints

### DIFF
--- a/src/components/CustomAudioPlayer.tsx
+++ b/src/components/CustomAudioPlayer.tsx
@@ -166,7 +166,7 @@ export const CustomAudioPlayer: React.FC<CustomAudioPlayerProps> = ({
     <Box
       component={motion.div}
       drag="y"
-      dragConstraints={{ top: -200, bottom: 200 }}
+      dragConstraints={{ top: -200, bottom: 0 }}
       dragElastic={0.5}
       dragMomentum={false}
       dragDirectionLock


### PR DESCRIPTION
## Summary
- Fixed issue where dragging the bottom sheet player downward created unwanted bottom margin/space

## Changes
- Changed `dragConstraints` bottom value from `200` to `0` in CustomAudioPlayer
- This prevents the player from being dragged downward past its original position
- Players can still be dragged upward to expand the full-screen view

## Problem
The bottom sheet player is positioned at `bottom: 0` with `position: fixed`. When `dragConstraints` allowed `bottom: 200`, dragging downward would move the player below the viewport, creating visible white space/margin below it.

## Solution
Restricting the bottom constraint to `0` ensures the player cannot be dragged below its original position, eliminating the unwanted visual gap.

## Test plan
- [x] Type check passed (`npx tsc --noEmit`)
- [x] Visual verification: No bottom margin appears when dragging the player
- [x] Upward drag still works to expand the player to full screen

## Before/After
- Before: Dragging down created ~200px of white space below the player
- After: Player stays at bottom position, no unwanted margin appears

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)