### PR TITLE
fix: remove hotaru background artifact

### DIFF
--- a/src/components/SkeletonScreen.tsx
+++ b/src/components/SkeletonScreen.tsx
@@ -179,25 +179,6 @@ export const RetroLoadingSpinner: React.FC<{ size?: number }> = () => {
         zIndex: 1000,
       }}
     >
-      {/* 睡蓮の葉（背景装飾） */}
-      <Box
-        sx={{
-          position: "absolute",
-          bottom: -40,
-          width: 80,
-          height: 80,
-          borderRadius: "50% 50% 50% 0",
-          background: "radial-gradient(circle at 30% 30%, rgba(0, 245, 212, 0.15), rgba(0, 150, 100, 0.1))",
-          transform: "rotate(-45deg)",
-          opacity: 0.4,
-          animation: "float 3s ease-in-out infinite",
-          "@keyframes float": {
-            "0%, 100%": { transform: "rotate(-45deg) translateY(0px)" },
-            "50%": { transform: "rotate(-45deg) translateY(-5px)" },
-          },
-        }}
-      />
-
       {/* 蛍たちが飛び回るコンテナ */}
       <Box
         sx={{


### PR DESCRIPTION
## Summary
- Issue #37 の実装
- Remove the stray lily-pad background shape from the firefly loading spinner so nothing odd appears behind Hotaru.

## Changes
- Delete the decorative background Box under  so only the fireflies are rendered over the overlay backdrop.

## Test plan
- [ ] npx tsc --noEmit *(blocked: repository TypeScript 5.8 requires Node >=18 but sandbox Node is v10.15.1, so running  throws \"Unexpected token ?\")*
- [ ] npm run lint *(blocked for the same Node runtime limitation when loading )*
- [ ] npm run build *(blocked for the same Node runtime limitation during )*

Closes #37