### PR TITLE
fix: メモのトースト表示をPWA向けに調整

### DIFF
--- a/src/components/MemoModal.tsx
+++ b/src/components/MemoModal.tsx
@@ -53,6 +53,51 @@ const isAuthorizationError = (error: unknown) => {
 
 const getMemoStorageKey = (folderId: string) => `${LOCAL_STORAGE_KEYS.USER_MEMO_PREFIX}${folderId}`;
 
+const memoSnackbarSx = {
+  top: "calc(64px + env(safe-area-inset-top)) !important",
+  zIndex: 1400,
+};
+
+const getMemoToastSx = (mode: "success" | "error") => ({
+  width: "100%",
+  minWidth: { xs: "min(92vw, 320px)", sm: "360px" },
+  alignItems: "center",
+  borderRadius: "14px",
+  border: mode === "success" ? "2px solid #00f5d4" : "2px solid #ff006e",
+  background:
+    mode === "success"
+      ? "linear-gradient(135deg, rgba(0, 245, 212, 0.92), rgba(0, 180, 216, 0.92))"
+      : "linear-gradient(135deg, rgba(255, 0, 110, 0.95), rgba(255, 77, 159, 0.95))",
+  backdropFilter: "blur(12px)",
+  boxShadow:
+    mode === "success"
+      ? "0 0 30px rgba(0, 245, 212, 0.45), 0 8px 32px rgba(0, 0, 0, 0.35)"
+      : "0 0 30px rgba(255, 0, 110, 0.55), 0 8px 32px rgba(0, 0, 0, 0.4)",
+  color: "#fff",
+  fontWeight: 700,
+  letterSpacing: "0.01em",
+  textShadow: "0 2px 10px rgba(0, 0, 0, 0.28)",
+  "& .MuiAlert-message": {
+    width: "100%",
+    py: 0.25,
+  },
+  "& .MuiAlert-icon": {
+    color: "#fbf8cc",
+    opacity: 1,
+  },
+  "& .MuiAlert-action": {
+    pt: 0.5,
+  },
+  "& .MuiIconButton-root": {
+    color: "#fff",
+    transition: "all 0.25s ease",
+    "&:hover": {
+      background: "rgba(255, 255, 255, 0.12)",
+      transform: "scale(1.08)",
+    },
+  },
+});
+
 const MemoModal: React.FC<MemoModalProps> = ({
   open,
   onClose,
@@ -464,8 +509,9 @@ const MemoModal: React.FC<MemoModalProps> = ({
         autoHideDuration={4000}
         onClose={handleFeedbackClose}
         anchorOrigin={{ vertical: "top", horizontal: "center" }}
+        sx={memoSnackbarSx}
       >
-        <Alert onClose={handleFeedbackClose} severity="success" variant="filled" sx={{ width: "100%" }}>
+        <Alert onClose={handleFeedbackClose} severity="success" variant="filled" sx={getMemoToastSx("success")}>
           {feedbackMessage}
         </Alert>
       </Snackbar>
@@ -474,8 +520,9 @@ const MemoModal: React.FC<MemoModalProps> = ({
         autoHideDuration={5000}
         onClose={handleErrorClose}
         anchorOrigin={{ vertical: "top", horizontal: "center" }}
+        sx={memoSnackbarSx}
       >
-        <Alert onClose={handleErrorClose} severity="error" variant="filled" sx={{ width: "100%" }}>
+        <Alert onClose={handleErrorClose} severity="error" variant="filled" sx={getMemoToastSx("error")}>
           {errorMessage}
         </Alert>
       </Snackbar>


### PR DESCRIPTION
## 概要
- メモ画面のトーストが iPhone PWA で上部に隠れやすい問題を調整
- メモ用トーストの見た目を既存のネオン系UIに寄せて統一感を改善
- 成功 / 失敗トーストの視認性を上げつつ、ダイアログ上でも見やすく整理

## 変更内容
- メモ用 `Snackbar` に `safe-area` とヘッダー高さを考慮した位置調整を追加
- メモ用トーストの `z-index` を上げて、PWA とダイアログ環境で隠れにくく調整
- 成功 / 失敗トーストにネオン調のグラデーション、発光、ブラー、ホバー表現を追加
- 既存アプリのトースト表現に合わせて、メモ画面の通知デザインを統一

## テスト計画
- [x] `npx tsc --noEmit`
- [x] `npm run lint`（既存 warning のみ）
- [ ] iPhone PWA でメモのトーストが上部に隠れないことを確認
- [ ] メモの成功 / 失敗通知がダイアログ上で見やすく表示されることを確認

🤖 Generated with [Codex CLI](https://openai.com/codex)
