### PR TITLE
fix: フォルダ切り替え時の再生維持と axios 依存の削除

### DIFF
--- a/docs/adr/0002-bundle-size-optimization.md
+++ b/docs/adr/0002-bundle-size-optimization.md
@@ -39,7 +39,7 @@ build: {
         'mui-icons': ['@mui/icons-material'],
         'vendor-react': ['react', 'react-dom'],
         'vendor-animation': ['framer-motion'],
-        'vendor-google': ['@react-oauth/google', 'gapi-script', 'axios'],
+        'vendor-google': ['@react-oauth/google', 'gapi-script'],
       },
     },
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@mui/icons-material": "^7.2.0",
         "@mui/material": "^7.2.0",
         "@react-oauth/google": "^0.12.2",
-        "axios": "^1.11.0",
         "framer-motion": "^12.23.12",
         "gapi-script": "^1.2.0",
         "react": "^19.1.0",
@@ -3914,12 +3913,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
     "node_modules/at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
@@ -3944,17 +3937,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/babel-plugin-macros": {
@@ -4129,6 +4111,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4240,18 +4223,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/commander": {
       "version": "2.20.3",
@@ -4526,15 +4497,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -4576,6 +4538,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -4704,6 +4667,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4713,6 +4677,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4729,6 +4694,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -4741,6 +4707,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5151,26 +5118,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -5202,22 +5149,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/framer-motion": {
@@ -5348,6 +5279,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -5379,6 +5311,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -5517,6 +5450,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5588,6 +5522,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5600,6 +5535,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -6836,6 +6772,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6847,27 +6784,6 @@
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/min-indent": {
       "version": "1.0.1",
@@ -7344,12 +7260,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
     "node_modules/punycode": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@mui/icons-material": "^7.2.0",
     "@mui/material": "^7.2.0",
     "@react-oauth/google": "^0.12.2",
-    "axios": "^1.11.0",
     "framer-motion": "^12.23.12",
     "gapi-script": "^1.2.0",
     "react": "^19.1.0",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,23 +1,15 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import axios from "axios";
-import type { AxiosRequestConfig } from "axios";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import App from "./App";
 import { GOOGLE_TOKEN_SCOPE_VERSION, LOCAL_STORAGE_KEYS } from "./constants";
 import type { DriveFile } from "./types";
 
-vi.mock("axios");
 vi.mock("@react-oauth/google", () => ({
   useGoogleLogin: () => vi.fn(),
 }));
 
-const mockedAxios = vi.mocked(axios);
-type AxiosGetMock = {
-  mockImplementation: (
-    implementation: (url: string, config?: AxiosRequestConfig) => Promise<{ data: unknown }>,
-  ) => void;
-};
+const mockedFetch = vi.fn<typeof fetch>();
 
 const folderOneTrack: DriveFile = {
   id: "track-1",
@@ -38,6 +30,7 @@ const folderTwoTrack: DriveFile = {
 describe("App", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubGlobal("fetch", mockedFetch);
     localStorage.clear();
     localStorage.setItem(LOCAL_STORAGE_KEYS.GOOGLE_ACCESS_TOKEN, "test-token");
     localStorage.setItem(LOCAL_STORAGE_KEYS.TOKEN_EXPIRY, String(Date.now() + 60_000));
@@ -57,19 +50,20 @@ describe("App", () => {
   });
 
   it("再生中にフォルダのプルダウンを変更しても音楽を停止しない", async () => {
-    (mockedAxios.get as unknown as AxiosGetMock).mockImplementation(async (url, config) => {
-      if (String(url).includes("alt=media")) {
-        return { data: new Blob(["audio"]) };
+    mockedFetch.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.includes("alt=media")) {
+        return new Response("audio", { status: 200 });
       }
 
-      const q = String(config?.params?.q ?? "");
+      const q = new URL(url).searchParams.get("q") ?? "";
       if (q.includes("'folder-one'")) {
-        return { data: { files: [folderOneTrack] } };
+        return Response.json({ files: [folderOneTrack] });
       }
       if (q.includes("'folder-two'")) {
-        return { data: { files: [folderTwoTrack] } };
+        return Response.json({ files: [folderTwoTrack] });
       }
-      return { data: { files: [] } };
+      return Response.json({ files: [] });
     });
 
     const user = userEvent.setup();

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import axios from "axios";
+import type { AxiosRequestConfig } from "axios";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import App from "./App";
+import { GOOGLE_TOKEN_SCOPE_VERSION, LOCAL_STORAGE_KEYS } from "./constants";
+import type { DriveFile } from "./types";
+
+vi.mock("axios");
+vi.mock("@react-oauth/google", () => ({
+  useGoogleLogin: () => vi.fn(),
+}));
+
+const mockedAxios = vi.mocked(axios);
+type AxiosGetMock = {
+  mockImplementation: (
+    implementation: (url: string, config?: AxiosRequestConfig) => Promise<{ data: unknown }>,
+  ) => void;
+};
+
+const folderOneTrack: DriveFile = {
+  id: "track-1",
+  name: "Folder One Song.mp3",
+  mimeType: "audio/mpeg",
+  modifiedTime: "2026-04-21T00:00:00.000Z",
+  parents: ["folder-one"],
+};
+
+const folderTwoTrack: DriveFile = {
+  id: "track-2",
+  name: "Folder Two Song.mp3",
+  mimeType: "audio/mpeg",
+  modifiedTime: "2026-04-20T00:00:00.000Z",
+  parents: ["folder-two"],
+};
+
+describe("App", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    localStorage.setItem(LOCAL_STORAGE_KEYS.GOOGLE_ACCESS_TOKEN, "test-token");
+    localStorage.setItem(LOCAL_STORAGE_KEYS.TOKEN_EXPIRY, String(Date.now() + 60_000));
+    localStorage.setItem(LOCAL_STORAGE_KEYS.TOKEN_SCOPE_VERSION, GOOGLE_TOKEN_SCOPE_VERSION);
+    localStorage.setItem(
+      LOCAL_STORAGE_KEYS.FOLDER_OPTIONS,
+      JSON.stringify([
+        { id: "all", name: "All Folders" },
+        { id: "folder-one", name: "Folder One" },
+        { id: "folder-two", name: "Folder Two" },
+      ]),
+    );
+
+    vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:audio-url");
+    vi.spyOn(HTMLMediaElement.prototype, "play").mockResolvedValue(undefined);
+    vi.spyOn(HTMLMediaElement.prototype, "pause").mockImplementation(() => undefined);
+  });
+
+  it("再生中にフォルダのプルダウンを変更しても音楽を停止しない", async () => {
+    (mockedAxios.get as unknown as AxiosGetMock).mockImplementation(async (url, config) => {
+      if (String(url).includes("alt=media")) {
+        return { data: new Blob(["audio"]) };
+      }
+
+      const q = String(config?.params?.q ?? "");
+      if (q.includes("'folder-one'")) {
+        return { data: { files: [folderOneTrack] } };
+      }
+      if (q.includes("'folder-two'")) {
+        return { data: { files: [folderTwoTrack] } };
+      }
+      return { data: { files: [] } };
+    });
+
+    const user = userEvent.setup();
+    const pauseSpy = vi.spyOn(HTMLMediaElement.prototype, "pause");
+
+    render(<App />);
+
+    await user.click(await screen.findByText("Folder One Song.mp3"));
+    await waitFor(() => {
+      expect(HTMLMediaElement.prototype.play).toHaveBeenCalled();
+    });
+
+    await user.click(screen.getByRole("combobox", { name: "フォルダを選択" }));
+    await user.click(await screen.findByRole("option", { name: "Folder Two" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Folder Two Song.mp3")).toBeInTheDocument();
+    });
+    expect(screen.getAllByText("Folder One Song.mp3").length).toBeGreaterThan(0);
+    expect(pauseSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,12 +23,12 @@ import CloudIcon from "@mui/icons-material/Cloud";
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
 // その他のライブラリ
 import { motion, AnimatePresence } from "framer-motion";
-import axios from "axios";
 import { useGoogleLogin } from "@react-oauth/google";
 import { CustomAudioPlayer } from "./components/CustomAudioPlayer.tsx";
 import { MusicListSkeleton, TrackSwitchingIndicator, RetroLoadingSpinner } from "./components/SkeletonScreen.tsx";
 import { type DriveFile, type FolderOption } from "./types";
 import { getCachedMusicFiles, cacheMusicFiles } from "./utils/cache";
+import { GoogleApiError, googleApiBlob, googleApiJson } from "./utils/googleApi";
 import {
   ALL_FOLDERS_OPTION,
   GOOGLE_DRIVE_SCOPE,
@@ -292,18 +292,18 @@ function App() {
 
         // キャッシュがない場合はAPIコール
         try {
-          const response = await axios.get("https://www.googleapis.com/drive/v3/files", {
-            headers: {
-              Authorization: `Bearer ${accessToken}`, // アクセストークンをヘッダーに含める
-            },
-            params: {
+          const response = await googleApiJson<{ files?: DriveFile[] }>(
+            "https://www.googleapis.com/drive/v3/files",
+            accessToken,
+            undefined,
+            {
               q: `'${folder.id}' in parents and mimeType contains 'audio/'`, // フォルダ内のオーディオファイルを検索
               fields: "files(id, name, mimeType, modifiedTime, parents)", // 取得するフィールドを指定
               supportsAllDrives: true,
               includeItemsFromAllDrives: true,
             },
-          });
-          const fetchedFiles = response.data.files || [];
+          );
+          const fetchedFiles = response.files || [];
           console.log(`[fetchMusicFiles] Fetched ${fetchedFiles.length} files from ${folder.name}`);
 
           // 取得したデータをキャッシュに保存（10分間有効）
@@ -311,7 +311,7 @@ function App() {
 
           allFiles.push(...fetchedFiles); // 取得したファイルをリストに追加
         } catch (folderError: unknown) {
-          if (axios.isAxiosError(folderError) && folderError.response?.status === 401) {
+          if (folderError instanceof GoogleApiError && folderError.status === 401) {
             // 認証エラーはすぐにログアウト
             setErrorMessage("認証エラー: 再度ログインしてください");
             handleLogout();
@@ -367,16 +367,13 @@ function App() {
     setPlayingLoading(true); // オーディオフェッチ開始時に再生ローディング状態をtrueに設定
     console.log("Playing loading set to true for file:", file.name);
     try {
-      const response = await axios.get(
-        `https://www.googleapis.com/drive/v3/files/${file.id}?alt=media`, // Google Driveからメディアコンテンツを取得
-        {
-          headers: {
-            Authorization: `Bearer ${accessToken}`, // アクセストークンをヘッダーに含める
-          },
-          responseType: "blob", // バイナリデータとしてレスポンスを受け取る
-        },
+      const audioBlob = await googleApiBlob(
+        `https://www.googleapis.com/drive/v3/files/${file.id}`, // Google Driveからメディアコンテンツを取得
+        accessToken ?? "",
+        undefined,
+        { alt: "media" },
       );
-      const audioUrl = URL.createObjectURL(response.data); // BlobからURLを作成
+      const audioUrl = URL.createObjectURL(audioBlob); // BlobからURLを作成
       if (audioRef.current) {
         audioRef.current.src = audioUrl; // audioソースを設定
         audioRef.current.play(); // 音楽を再生

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -240,20 +240,14 @@ function App() {
 
   // フォルダフィルタリングの変更ハンドラ
   const handleFilterFolderChange = async (event: SelectChangeEvent<string>) => {
-    // 音楽を停止
-    setSelectedFile(null);
-    setPlayingLoading(false);
-    if (audioRef.current) {
-      audioRef.current.pause();
-      audioRef.current.src = "";
-    }
+    const nextFolderId = event.target.value;
 
     // トランジション開始
     setIsTransitioning(true);
 
     // 少し待ってからフォルダ切り替え
     await new Promise(resolve => setTimeout(resolve, 150));
-    setCurrentFilterFolderId(event.target.value);
+    setCurrentFilterFolderId(nextFolderId);
 
     // トランジション完了
     await new Promise(resolve => setTimeout(resolve, 200));
@@ -344,7 +338,7 @@ function App() {
     } finally {
       setLoading(false); // フェッチ完了後にローディング状態をfalseに設定
     }
-  }, [accessToken, folderOptions]);
+  }, [accessToken, folderOptions, handleLogout]);
 
   // アクセストークンが取得できたら音楽ファイルをフェッチ
   useEffect(() => {

--- a/src/components/FolderManagement.test.tsx
+++ b/src/components/FolderManagement.test.tsx
@@ -2,11 +2,9 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render } from "@testing-library/react";
 import { screen, waitFor } from "@testing-library/dom";
 import userEvent from "@testing-library/user-event";
-import axios from "axios";
 import FolderManagement from "./FolderManagement";
 
-vi.mock("axios");
-const mockedAxios = vi.mocked(axios);
+const mockedFetch = vi.fn<typeof fetch>();
 
 const defaultProps = {
   open: true,
@@ -17,6 +15,7 @@ const defaultProps = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.stubGlobal("fetch", mockedFetch);
 });
 
 describe("FolderManagement", () => {
@@ -26,9 +25,9 @@ describe("FolderManagement", () => {
   });
 
   it("正しいフォルダIDを入力すると folderName が自動入力されて Add が有効になる", async () => {
-    mockedAxios.get = vi.fn().mockResolvedValue({
-      data: { name: "My Music", mimeType: "application/vnd.google-apps.folder" },
-    });
+    mockedFetch.mockImplementation(async () =>
+      Response.json({ name: "My Music", mimeType: "application/vnd.google-apps.folder" }),
+    );
 
     render(<FolderManagement {...defaultProps} />);
     await userEvent.type(screen.getByLabelText("Folder ID"), "valid-folder-id");
@@ -40,11 +39,7 @@ describe("FolderManagement", () => {
   });
 
   it("存在しないフォルダIDを入力するとエラーが表示されて Add が無効のまま", async () => {
-    mockedAxios.get = vi.fn().mockRejectedValue({
-      isAxiosError: true,
-      response: { status: 404 },
-      message: "Not Found",
-    });
+    mockedFetch.mockImplementation(async () => new Response(null, { status: 404 }));
 
     render(<FolderManagement {...defaultProps} />);
     await userEvent.type(screen.getByLabelText("Folder ID"), "wrong-id");
@@ -58,9 +53,9 @@ describe("FolderManagement", () => {
   });
 
   it("フォルダIDがフォルダでない場合にエラーが表示される", async () => {
-    mockedAxios.get = vi.fn().mockResolvedValue({
-      data: { name: "Not a folder", mimeType: "application/vnd.google-apps.document" },
-    });
+    mockedFetch.mockImplementation(async () =>
+      Response.json({ name: "Not a folder", mimeType: "application/vnd.google-apps.document" }),
+    );
 
     render(<FolderManagement {...defaultProps} />);
     await userEvent.type(screen.getByLabelText("Folder ID"), "file-id-not-folder");
@@ -74,7 +69,7 @@ describe("FolderManagement", () => {
   });
 
   it("エラー時は Folder Name フィールドが入力不可", async () => {
-    mockedAxios.get = vi.fn().mockRejectedValue(new Error("Network Error"));
+    mockedFetch.mockRejectedValue(new Error("Network Error"));
 
     render(<FolderManagement {...defaultProps} />);
     await userEvent.type(screen.getByLabelText("Folder ID"), "bad-id");
@@ -85,9 +80,9 @@ describe("FolderManagement", () => {
   });
 
   it("Add クリックで onAddFolder が正しい引数で呼ばれる", async () => {
-    mockedAxios.get = vi.fn().mockResolvedValue({
-      data: { name: "My Music", mimeType: "application/vnd.google-apps.folder" },
-    });
+    mockedFetch.mockImplementation(async () =>
+      Response.json({ name: "My Music", mimeType: "application/vnd.google-apps.folder" }),
+    );
 
     render(<FolderManagement {...defaultProps} />);
     await userEvent.type(screen.getByLabelText("Folder ID"), "valid-id");

--- a/src/components/FolderManagement.tsx
+++ b/src/components/FolderManagement.tsx
@@ -7,9 +7,9 @@ import DialogActions from "@mui/material/DialogActions";
 import TextField from "@mui/material/TextField";
 import Button from "@mui/material/Button";
 import CircularProgress from "@mui/material/CircularProgress";
-import axios from "axios";
 import { type FolderManagementProps } from "../types";
 import { getCachedFolderMetadata, cacheFolderMetadata } from "../utils/cache";
+import { googleApiJson } from "../utils/googleApi";
 
 /**
  * フォルダ管理モーダルコンポーネント。
@@ -57,27 +57,24 @@ const FolderManagement: React.FC<FolderManagementProps> = ({
 
         // キャッシュがない場合はAPIコール
         try {
-          const response = await axios.get(
+          const response = await googleApiJson<{ name: string; mimeType: string }>(
             `https://www.googleapis.com/drive/v3/files/${folderId}`,
+            accessToken,
+            undefined,
             {
-              headers: {
-                Authorization: `Bearer ${accessToken}`,
-              },
-              params: {
-                fields: "name,mimeType",
-                supportsAllDrives: true,
-              },
+              fields: "name,mimeType",
+              supportsAllDrives: true,
             },
           );
 
           // 取得したデータをキャッシュに保存（30分間有効）
           cacheFolderMetadata(folderId, {
-            name: response.data.name,
-            mimeType: response.data.mimeType,
+            name: response.name,
+            mimeType: response.mimeType,
           });
 
-          if (response.data.mimeType === "application/vnd.google-apps.folder") {
-            setFolderName(response.data.name);
+          if (response.mimeType === "application/vnd.google-apps.folder") {
+            setFolderName(response.name);
           } else {
             setError("The provided ID is not a folder ID.");
             setFolderName("");

--- a/src/components/MemoModal.tsx
+++ b/src/components/MemoModal.tsx
@@ -18,7 +18,6 @@ import Divider from "@mui/material/Divider";
 import CircularProgress from "@mui/material/CircularProgress";
 import { motion, AnimatePresence } from "framer-motion";
 import DeleteIcon from "@mui/icons-material/Delete";
-import axios from "axios";
 import { TODO_FILE_NAME, LOCAL_STORAGE_KEYS } from "../constants";
 import { type MemoModalProps, type Task } from "../types";
 import {
@@ -38,10 +37,11 @@ import {
   loadTasksFromNotion,
   saveTasksToNotion,
 } from "../utils/notionTodo";
+import { GoogleApiError } from "../utils/googleApi";
 
 const isAuthorizationError = (error: unknown) => {
-  if (axios.isAxiosError(error)) {
-    return error.response?.status === 401 || error.response?.status === 403;
+  if (error instanceof GoogleApiError) {
+    return error.status === 401 || error.status === 403;
   }
 
   if (error instanceof Error) {

--- a/src/utils/driveTodo.ts
+++ b/src/utils/driveTodo.ts
@@ -1,5 +1,5 @@
-import axios from "axios";
 import { TODO_FILE_NAME } from "../constants";
+import { googleApiJson, googleApiText } from "./googleApi";
 
 export interface DriveTodoFile {
   id: string;
@@ -22,31 +22,26 @@ const buildMultipartBody = (metadata: Record<string, unknown>, content: string, 
 };
 
 export const findTodoFileInFolder = async (accessToken: string, folderId: string) => {
-  const response = await axios.get("https://www.googleapis.com/drive/v3/files", {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
-    params: {
+  const response = await googleApiJson<{ files?: DriveTodoFile[] }>(
+    "https://www.googleapis.com/drive/v3/files",
+    accessToken,
+    undefined,
+    {
       q: `'${folderId}' in parents and name='${TODO_FILE_NAME}' and trashed=false`,
       fields: "files(id,name,modifiedTime)",
       pageSize: 1,
       supportsAllDrives: true,
       includeItemsFromAllDrives: true,
     },
-  });
+  );
 
-  return (response.data.files?.[0] as DriveTodoFile | undefined) ?? null;
+  return response.files?.[0] ?? null;
 };
 
 export const readTodoFile = async (accessToken: string, fileId: string) => {
-  const response = await axios.get(`https://www.googleapis.com/drive/v3/files/${fileId}?alt=media`, {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
-    responseType: "text",
+  return googleApiText(`https://www.googleapis.com/drive/v3/files/${fileId}`, accessToken, undefined, {
+    alt: "media",
   });
-
-  return typeof response.data === "string" ? response.data : String(response.data);
 };
 
 export const createTodoFile = async (accessToken: string, folderId: string, content: string) => {
@@ -104,4 +99,3 @@ export const updateTodoFile = async (accessToken: string, fileId: string, conten
 
   return (await response.json()) as DriveTodoFile;
 };
-

--- a/src/utils/googleApi.ts
+++ b/src/utils/googleApi.ts
@@ -1,0 +1,75 @@
+export class GoogleApiError extends Error {
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "GoogleApiError";
+    this.status = status;
+  }
+}
+
+const buildUrl = (url: string, params?: Record<string, string | number | boolean | undefined>) => {
+  if (!params) {
+    return url;
+  }
+
+  const nextUrl = new URL(url);
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined) {
+      nextUrl.searchParams.set(key, String(value));
+    }
+  });
+
+  return nextUrl.toString();
+};
+
+const request = async (
+  url: string,
+  accessToken: string,
+  init?: RequestInit,
+  params?: Record<string, string | number | boolean | undefined>,
+) => {
+  const response = await fetch(buildUrl(url, params), {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      ...(init?.headers ?? {}),
+    },
+  });
+
+  if (!response.ok) {
+    throw new GoogleApiError(`Google API request failed: ${response.status}`, response.status);
+  }
+
+  return response;
+};
+
+export const googleApiJson = async <T>(
+  url: string,
+  accessToken: string,
+  init?: RequestInit,
+  params?: Record<string, string | number | boolean | undefined>,
+) => {
+  const response = await request(url, accessToken, init, params);
+  return (await response.json()) as T;
+};
+
+export const googleApiText = async (
+  url: string,
+  accessToken: string,
+  init?: RequestInit,
+  params?: Record<string, string | number | boolean | undefined>,
+) => {
+  const response = await request(url, accessToken, init, params);
+  return response.text();
+};
+
+export const googleApiBlob = async (
+  url: string,
+  accessToken: string,
+  init?: RequestInit,
+  params?: Record<string, string | number | boolean | undefined>,
+) => {
+  const response = await request(url, accessToken, init, params);
+  return response.blob();
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -137,7 +137,7 @@ export default defineConfig(({ mode }) => {
             if (id.includes("framer-motion")) {
               return "vendor-animation";
             }
-            if (id.includes("@react-oauth/google") || id.includes("gapi-script") || id.includes("axios")) {
+            if (id.includes("@react-oauth/google") || id.includes("gapi-script")) {
               return "vendor-google";
             }
           },


### PR DESCRIPTION
## 概要
- フォルダ切り替え時に再生中の音楽が止まらないよう挙動を修正
- Google Drive まわりの通信を `fetch` ベースに統一し、`axios` 依存を削除

## 変更内容
- 再生中にフォルダのプルダウンを変更しても `pause` しないよう再生状態の扱いを調整
- Google Drive API 呼び出し用の共通ヘルパー `src/utils/googleApi.ts` を追加
- `App.tsx`、`FolderManagement.tsx`、`MemoModal.tsx`、`driveTodo.ts` の `axios` 利用を `fetch` ベースへ置き換え
- `axios` を依存関係とバンドル分割設定から削除
- 関連テストを `fetch` モック前提へ更新

## テスト
- [x] `npm test`
- [x] `npm run build`

## 補足
- この PR にはフォルダ切り替え時の再生維持修正と axios 削除の両方が含まれます

Closes #47

🤖 Generated with [Codex CLI](https://openai.com/codex)