### PR TITLE
[codex] Fix toast overlap near memo controls

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1018,9 +1018,14 @@ function App() {
         autoHideDuration={4000}
         onClose={handleSnackbarClose}
         message={snackbarMessage}
-        anchorOrigin={{ vertical: "top", horizontal: "center" }}
+        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
         sx={{
-          top: "calc(64px + env(safe-area-inset-top)) !important",
+          bottom: selectedFile
+            ? {
+                xs: "calc(208px + env(safe-area-inset-bottom)) !important",
+                sm: "calc(176px + env(safe-area-inset-bottom)) !important",
+              }
+            : "calc(24px + env(safe-area-inset-bottom)) !important",
           zIndex: 1300,
         }}
         slotProps={{

--- a/src/components/MemoModal.tsx
+++ b/src/components/MemoModal.tsx
@@ -54,13 +54,18 @@ const isAuthorizationError = (error: unknown) => {
 const getMemoStorageKey = (folderId: string) => `${LOCAL_STORAGE_KEYS.USER_MEMO_PREFIX}${folderId}`;
 
 const memoSnackbarSx = {
-  top: "calc(64px + env(safe-area-inset-top)) !important",
+  top: {
+    xs: "calc(88px + env(safe-area-inset-top)) !important",
+    sm: "calc(24px + env(safe-area-inset-top)) !important",
+  },
+  right: { xs: "12px !important", sm: "24px !important" },
+  left: { xs: "12px !important", sm: "auto !important" },
   zIndex: 1400,
 };
 
 const getMemoToastSx = (mode: "success" | "error") => ({
   width: "100%",
-  minWidth: { xs: "min(92vw, 320px)", sm: "360px" },
+  minWidth: { xs: "auto", sm: "360px" },
   alignItems: "center",
   borderRadius: "14px",
   border: mode === "success" ? "2px solid #00f5d4" : "2px solid #ff006e",
@@ -508,7 +513,7 @@ const MemoModal: React.FC<MemoModalProps> = ({
         open={feedbackMessage !== null}
         autoHideDuration={4000}
         onClose={handleFeedbackClose}
-        anchorOrigin={{ vertical: "top", horizontal: "center" }}
+        anchorOrigin={{ vertical: "top", horizontal: "right" }}
         sx={memoSnackbarSx}
       >
         <Alert onClose={handleFeedbackClose} severity="success" variant="filled" sx={getMemoToastSx("success")}>
@@ -519,7 +524,7 @@ const MemoModal: React.FC<MemoModalProps> = ({
         open={errorMessage !== null}
         autoHideDuration={5000}
         onClose={handleErrorClose}
-        anchorOrigin={{ vertical: "top", horizontal: "center" }}
+        anchorOrigin={{ vertical: "top", horizontal: "right" }}
         sx={memoSnackbarSx}
       >
         <Alert onClose={handleErrorClose} severity="error" variant="filled" sx={getMemoToastSx("error")}>


### PR DESCRIPTION
## Summary
- Move the shared app Snackbar away from the top memo/filter controls to the bottom of the viewport.
- Offset the shared Snackbar above the custom audio player when a track is selected.
- Reposition MemoModal success/error toasts to the top-right, with extra mobile top spacing so they do not cover the modal title.

## Validation
- `npm run build`
- `npm run test`
- `npm run lint` (passes with existing generated `coverage/` warnings)

Closes #52