### PR TITLE
[codex] Add realtime websocket sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ VITE_GOOGLE_CLIENT_ID=your_client_id_here
 VITE_NOTION_SYNC_PAGE_ID=your_notion_page_id_here
 NOTION_API_KEY=your_notion_integration_secret
 
+# WebSocket リアルタイム同期を使う場合
+VITE_SYNC_WEBSOCKET_URL=wss://your-sync-server.example.com
+
 # 開発サーバーを起動
 npm run dev
 ```
@@ -110,6 +113,7 @@ npm run preview
 5. **共有**: 共有アイコンから曲のリンクをコピー
 6. **制作TODO運用**: 曲フォルダを選んで `メモ` を開くと、そのフォルダ内の `TODO.md` を自動で読み込みます。保存すると同じ Drive フォルダ内の `TODO.md` を更新します。
 7. **Notion同期**: `VITE_NOTION_SYNC_PAGE_ID` と `NOTION_API_KEY` を設定すると、`メモ` 画面から `Notionから読込` / `Notionへ保存` が使えます。Notion ページ内には `App TODO Sync: <フォルダ名>` のトグルブロックを作り、その子要素のチェックリストだけを同期します。
+8. **リアルタイム同期**: `VITE_SYNC_WEBSOCKET_URL` を設定すると、フォルダ一覧とメモの変更を WebSocket 経由で他の画面へ同期します。未設定でも同じブラウザ内の別タブは BroadcastChannel で同期します。
 
 ## 🎛 iPhone PWA での TODO 運用
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ import {
 import { type DriveFile, type FolderOption } from "./types";
 import { getCachedMusicFiles, cacheMusicFiles } from "./utils/cache";
 import { GoogleApiError, googleApiBlob, googleApiJson } from "./utils/googleApi";
+import { publishRealtimeSync, subscribeRealtimeSync } from "./utils/realtimeSync";
 import {
   ALL_FOLDERS_OPTION,
   GOOGLE_DRIVE_SCOPE,
@@ -63,9 +64,35 @@ function App() {
     }
   });
 
-  // folderOptionsが変更されるたびにlocalStorageに保存
+  const applyingRemoteFolderOptionsRef = useRef(false);
+  const didInitializeFolderSyncRef = useRef(false);
+
+  useEffect(() => {
+    return subscribeRealtimeSync((message) => {
+      if (message.type !== "folder-options") {
+        return;
+      }
+
+      applyingRemoteFolderOptionsRef.current = true;
+      setFolderOptions(message.folderOptions);
+    });
+  }, []);
+
+  // folderOptionsが変更されるたびにlocalStorageに保存し、他の画面へ同期する
   useEffect(() => {
     localStorage.setItem(LOCAL_STORAGE_KEYS.FOLDER_OPTIONS, JSON.stringify(folderOptions));
+
+    if (!didInitializeFolderSyncRef.current) {
+      didInitializeFolderSyncRef.current = true;
+      return;
+    }
+
+    if (applyingRemoteFolderOptionsRef.current) {
+      applyingRemoteFolderOptionsRef.current = false;
+      return;
+    }
+
+    publishRealtimeSync({ type: "folder-options", folderOptions });
   }, [folderOptions]);
 
   // アクセストークン（Drive APIコール用）
@@ -126,6 +153,12 @@ function App() {
   const [snackbarMessage, setSnackbarMessage] = useState("");
   const [undoFolder, setUndoFolder] = useState<FolderOption | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!folderOptions.some((folder) => folder.id === currentFilterFolderId)) {
+      setCurrentFilterFolderId(ALL_FOLDERS_OPTION.id);
+    }
+  }, [currentFilterFolderId, folderOptions]);
 
   // フォルダを曲の最新更新日時でソート
   const sortedFolderOptions = useMemo(() => {

--- a/src/components/MemoModal.tsx
+++ b/src/components/MemoModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import Dialog from "@mui/material/Dialog";
 import DialogTitle from "@mui/material/DialogTitle";
 import DialogContent from "@mui/material/DialogContent";
@@ -20,12 +20,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import DeleteIcon from "@mui/icons-material/Delete";
 import { TODO_FILE_NAME, LOCAL_STORAGE_KEYS } from "../constants";
 import { type MemoModalProps, type Task } from "../types";
-import {
-  createTask,
-  parseTasksFromText,
-  sortTasks,
-  tasksToMarkdown,
-} from "../utils/tasks";
+import { createTask, parseTasksFromText, sortTasks, tasksToMarkdown } from "../utils/tasks";
 import {
   createTodoFile,
   findTodoFileInFolder,
@@ -38,6 +33,7 @@ import {
   saveTasksToNotion,
 } from "../utils/notionTodo";
 import { GoogleApiError } from "../utils/googleApi";
+import { publishRealtimeSync, subscribeRealtimeSync } from "../utils/realtimeSync";
 
 const isAuthorizationError = (error: unknown) => {
   if (error instanceof GoogleApiError) {
@@ -119,15 +115,19 @@ const MemoModal: React.FC<MemoModalProps> = ({
   const [isLoadingTodo, setIsLoadingTodo] = useState(false);
   const [isSavingTodo, setIsSavingTodo] = useState(false);
   const [isSyncingNotion, setIsSyncingNotion] = useState(false);
+  const latestRemoteMemoTimestampRef = useRef(0);
   const notionSyncEnabled = isNotionSyncConfigured();
 
-  const cacheTasksLocally = useCallback((currentTasks: Task[]) => {
-    if (!folderId || folderId === "all") {
-      return;
-    }
+  const cacheTasksLocally = useCallback(
+    (currentTasks: Task[]) => {
+      if (!folderId || folderId === "all") {
+        return;
+      }
 
-    localStorage.setItem(getMemoStorageKey(folderId), JSON.stringify(currentTasks));
-  }, [folderId]);
+      localStorage.setItem(getMemoStorageKey(folderId), JSON.stringify(currentTasks));
+    },
+    [folderId],
+  );
 
   const loadTasksFromLocalCache = useCallback(() => {
     if (!folderId || folderId === "all") {
@@ -147,6 +147,38 @@ const MemoModal: React.FC<MemoModalProps> = ({
     }
   }, [folderId]);
 
+  const applyTasksUpdate = useCallback(
+    (nextTasks: Task[], options: { publish?: boolean } = {}) => {
+      const sortedTasks = sortTasks(nextTasks);
+      setTasks(sortedTasks);
+      cacheTasksLocally(sortedTasks);
+
+      if (options.publish && folderId && folderId !== "all") {
+        publishRealtimeSync({ type: "memo-tasks", folderId, tasks: sortedTasks });
+      }
+    },
+    [cacheTasksLocally, folderId],
+  );
+
+  useEffect(() => {
+    return subscribeRealtimeSync((message) => {
+      if (message.type !== "memo-tasks" || message.folderId !== folderId) {
+        return;
+      }
+
+      if (message.timestamp <= latestRemoteMemoTimestampRef.current) {
+        return;
+      }
+
+      latestRemoteMemoTimestampRef.current = message.timestamp;
+      const syncedTasks = sortTasks(message.tasks);
+      setTasks(syncedTasks);
+      cacheTasksLocally(syncedTasks);
+      setFeedbackMessage("別の画面から TODO を同期しました。");
+      setErrorMessage(null);
+    });
+  }, [cacheTasksLocally, folderId]);
+
   useEffect(() => {
     if (!open) {
       return;
@@ -162,7 +194,7 @@ const MemoModal: React.FC<MemoModalProps> = ({
     }
 
     if (!accessToken) {
-      setTasks(loadTasksFromLocalCache());
+      applyTasksUpdate(loadTasksFromLocalCache());
       setTodoFileId(null);
       setErrorMessage(
         notionSyncEnabled
@@ -179,7 +211,7 @@ const MemoModal: React.FC<MemoModalProps> = ({
 
         if (!todoFile) {
           const cachedTasks = loadTasksFromLocalCache();
-          setTasks(cachedTasks);
+          applyTasksUpdate(cachedTasks);
           setTodoFileId(null);
           setFeedbackMessage(
             cachedTasks.length > 0
@@ -192,9 +224,8 @@ const MemoModal: React.FC<MemoModalProps> = ({
         const content = await readTodoFile(accessToken, todoFile.id);
         const loadedTasks = parseTasksFromText(content);
 
-        setTasks(loadedTasks);
+        applyTasksUpdate(loadedTasks);
         setTodoFileId(todoFile.id);
-        cacheTasksLocally(loadedTasks);
         setFeedbackMessage(`${TODO_FILE_NAME} を Drive から読み込みました。`);
       } catch (error) {
         console.error("Failed to load TODO from Drive", error);
@@ -206,7 +237,7 @@ const MemoModal: React.FC<MemoModalProps> = ({
         }
 
         const cachedTasks = loadTasksFromLocalCache();
-        setTasks(cachedTasks);
+        applyTasksUpdate(cachedTasks);
         setErrorMessage("Drive から TODO を読み込めなかったため、端末内の下書きを表示しています。");
       } finally {
         setIsLoadingTodo(false);
@@ -214,7 +245,15 @@ const MemoModal: React.FC<MemoModalProps> = ({
     };
 
     void loadTodo();
-  }, [open, folderId, accessToken, notionSyncEnabled, onAuthError, cacheTasksLocally, loadTasksFromLocalCache]);
+  }, [
+    open,
+    folderId,
+    accessToken,
+    notionSyncEnabled,
+    onAuthError,
+    applyTasksUpdate,
+    loadTasksFromLocalCache,
+  ]);
 
   const handleAddTask = () => {
     if (newTask.trim() === "") {
@@ -222,8 +261,7 @@ const MemoModal: React.FC<MemoModalProps> = ({
     }
 
     const newTasks = [createTask(newTask.trim()), ...tasks];
-    setTasks(newTasks);
-    cacheTasksLocally(newTasks);
+    applyTasksUpdate(newTasks, { publish: true });
     setNewTask("");
     setFeedbackMessage(null);
     setErrorMessage(null);
@@ -233,16 +271,14 @@ const MemoModal: React.FC<MemoModalProps> = ({
     const newTasks = sortTasks(
       tasks.map((task) => (task.id === id ? { ...task, completed: !task.completed } : task)),
     );
-    setTasks(newTasks);
-    cacheTasksLocally(newTasks);
+    applyTasksUpdate(newTasks, { publish: true });
     setFeedbackMessage(null);
     setErrorMessage(null);
   };
 
   const handleDeleteTask = (id: string) => {
     const newTasks = tasks.filter((task) => task.id !== id);
-    setTasks(newTasks);
-    cacheTasksLocally(newTasks);
+    applyTasksUpdate(newTasks, { publish: true });
     setFeedbackMessage(null);
     setErrorMessage(null);
   };
@@ -260,7 +296,7 @@ const MemoModal: React.FC<MemoModalProps> = ({
       const todoFile = await findTodoFileInFolder(accessToken, folderId);
       if (!todoFile) {
         const cachedTasks = loadTasksFromLocalCache();
-        setTasks(cachedTasks);
+        applyTasksUpdate(cachedTasks, { publish: true });
         setTodoFileId(null);
         setFeedbackMessage(
           cachedTasks.length > 0
@@ -273,9 +309,8 @@ const MemoModal: React.FC<MemoModalProps> = ({
       const content = await readTodoFile(accessToken, todoFile.id);
       const loadedTasks = parseTasksFromText(content);
 
-      setTasks(loadedTasks);
+      applyTasksUpdate(loadedTasks, { publish: true });
       setTodoFileId(todoFile.id);
-      cacheTasksLocally(loadedTasks);
       setFeedbackMessage(`${TODO_FILE_NAME} を再読み込みしました。`);
     } catch (error) {
       console.error("Failed to reload TODO from Drive", error);
@@ -345,8 +380,7 @@ const MemoModal: React.FC<MemoModalProps> = ({
 
     try {
       const result = await loadTasksFromNotion(folderName);
-      setTasks(result.tasks);
-      cacheTasksLocally(result.tasks);
+      applyTasksUpdate(result.tasks, { publish: true });
       setFeedbackMessage(
         result.found
           ? "Notion の App TODO Sync から読み込みました。"
@@ -354,7 +388,9 @@ const MemoModal: React.FC<MemoModalProps> = ({
       );
     } catch (error) {
       console.error("Failed to load TODO from Notion", error);
-      setErrorMessage(error instanceof Error ? error.message : "Notion から TODO を読み込めませんでした。");
+      setErrorMessage(
+        error instanceof Error ? error.message : "Notion から TODO を読み込めませんでした。",
+      );
     } finally {
       setIsSyncingNotion(false);
     }
@@ -408,22 +444,60 @@ const MemoModal: React.FC<MemoModalProps> = ({
         <DialogContent>
           <Stack spacing={1.5} sx={{ mb: 2, mt: 1 }}>
             {folderId === "all" && (
-              <Alert severity="warning">TODO を使うには「All Folders」以外の曲フォルダを選択してください。</Alert>
+              <Alert severity="warning">
+                TODO を使うには「All Folders」以外の曲フォルダを選択してください。
+              </Alert>
             )}
             <Stack direction={{ xs: "column", sm: "row" }} spacing={1}>
-              <Button onClick={handleReloadFromDrive} variant="outlined" disabled={folderId === "all" || isLoadingTodo || isSavingTodo || isSyncingNotion || !accessToken}>
+              <Button
+                onClick={handleReloadFromDrive}
+                variant="outlined"
+                disabled={
+                  folderId === "all" ||
+                  isLoadingTodo ||
+                  isSavingTodo ||
+                  isSyncingNotion ||
+                  !accessToken
+                }
+              >
                 Driveから再読込
               </Button>
-              <Button onClick={handleLoadFromNotion} variant="outlined" disabled={folderId === "all" || isLoadingTodo || isSavingTodo || isSyncingNotion || !notionSyncEnabled}>
+              <Button
+                onClick={handleLoadFromNotion}
+                variant="outlined"
+                disabled={
+                  folderId === "all" ||
+                  isLoadingTodo ||
+                  isSavingTodo ||
+                  isSyncingNotion ||
+                  !notionSyncEnabled
+                }
+              >
                 {isSyncingNotion ? "Notion同期中..." : "Notionから読込"}
               </Button>
-              <Button onClick={handleSaveToNotion} variant="outlined" disabled={folderId === "all" || isLoadingTodo || isSavingTodo || isSyncingNotion || !notionSyncEnabled}>
+              <Button
+                onClick={handleSaveToNotion}
+                variant="outlined"
+                disabled={
+                  folderId === "all" ||
+                  isLoadingTodo ||
+                  isSavingTodo ||
+                  isSyncingNotion ||
+                  !notionSyncEnabled
+                }
+              >
                 {isSyncingNotion ? "Notion同期中..." : "Notionへ保存"}
               </Button>
             </Stack>
           </Stack>
           {isLoadingTodo ? (
-            <Stack direction="row" spacing={1} alignItems="center" justifyContent="center" sx={{ py: 6 }}>
+            <Stack
+              direction="row"
+              spacing={1}
+              alignItems="center"
+              justifyContent="center"
+              sx={{ py: 6 }}
+            >
               <CircularProgress size={24} />
               <span>Drive から TODO を読み込み中...</span>
             </Stack>
@@ -446,7 +520,12 @@ const MemoModal: React.FC<MemoModalProps> = ({
                 }}
                 disabled={folderId === "all" || isSyncingNotion}
               />
-              <Button onClick={handleAddTask} variant="contained" sx={{ mt: 2, mb: 2 }} disabled={folderId === "all" || isSyncingNotion}>
+              <Button
+                onClick={handleAddTask}
+                variant="contained"
+                sx={{ mt: 2, mb: 2 }}
+                disabled={folderId === "all" || isSyncingNotion}
+              >
                 Add Task
               </Button>
               <Divider />
@@ -503,8 +582,14 @@ const MemoModal: React.FC<MemoModalProps> = ({
           )}
         </DialogContent>
         <DialogActions>
-          <Button onClick={handleClose} disabled={isSavingTodo || isSyncingNotion}>Cancel</Button>
-          <Button onClick={handleSaveMemo} variant="contained" disabled={folderId === "all" || isLoadingTodo || isSavingTodo || isSyncingNotion}>
+          <Button onClick={handleClose} disabled={isSavingTodo || isSyncingNotion}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSaveMemo}
+            variant="contained"
+            disabled={folderId === "all" || isLoadingTodo || isSavingTodo || isSyncingNotion}
+          >
             {isSavingTodo ? "Driveに保存中..." : "Driveに保存"}
           </Button>
         </DialogActions>
@@ -516,7 +601,12 @@ const MemoModal: React.FC<MemoModalProps> = ({
         anchorOrigin={{ vertical: "top", horizontal: "right" }}
         sx={memoSnackbarSx}
       >
-        <Alert onClose={handleFeedbackClose} severity="success" variant="filled" sx={getMemoToastSx("success")}>
+        <Alert
+          onClose={handleFeedbackClose}
+          severity="success"
+          variant="filled"
+          sx={getMemoToastSx("success")}
+        >
           {feedbackMessage}
         </Alert>
       </Snackbar>
@@ -527,7 +617,12 @@ const MemoModal: React.FC<MemoModalProps> = ({
         anchorOrigin={{ vertical: "top", horizontal: "right" }}
         sx={memoSnackbarSx}
       >
-        <Alert onClose={handleErrorClose} severity="error" variant="filled" sx={getMemoToastSx("error")}>
+        <Alert
+          onClose={handleErrorClose}
+          severity="error"
+          variant="filled"
+          sx={getMemoToastSx("error")}
+        >
           {errorMessage}
         </Alert>
       </Snackbar>

--- a/src/utils/realtimeSync.ts
+++ b/src/utils/realtimeSync.ts
@@ -1,0 +1,201 @@
+import { type FolderOption, type Task } from "../types";
+
+type FolderOptionsSyncMessage = {
+  type: "folder-options";
+  folderOptions: FolderOption[];
+};
+
+type MemoTasksSyncMessage = {
+  type: "memo-tasks";
+  folderId: string;
+  tasks: Task[];
+};
+
+export type RealtimeSyncPayload = FolderOptionsSyncMessage | MemoTasksSyncMessage;
+
+export type RealtimeSyncMessage = RealtimeSyncPayload & {
+  sourceId: string;
+  timestamp: number;
+};
+
+type RealtimeSyncListener = (message: RealtimeSyncMessage) => void;
+
+const CHANNEL_NAME = "gd-player-realtime-sync";
+const STORAGE_EVENT_KEY = "gd-player:realtime-sync";
+const syncWebSocketUrl = import.meta.env.VITE_SYNC_WEBSOCKET_URL?.trim() ?? "";
+
+const sourceId =
+  typeof crypto !== "undefined" && "randomUUID" in crypto
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+
+const listeners = new Set<RealtimeSyncListener>();
+
+let started = false;
+let broadcastChannel: BroadcastChannel | null = null;
+let socket: WebSocket | null = null;
+const pendingSocketMessages: RealtimeSyncMessage[] = [];
+
+const isTask = (value: unknown): value is Task => {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const task = value as Partial<Task>;
+  return (
+    typeof task.id === "string" &&
+    typeof task.text === "string" &&
+    typeof task.completed === "boolean"
+  );
+};
+
+const isFolderOption = (value: unknown): value is FolderOption => {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const folder = value as Partial<FolderOption>;
+  return typeof folder.id === "string" && typeof folder.name === "string";
+};
+
+const isRealtimeSyncMessage = (value: unknown): value is RealtimeSyncMessage => {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const message = value as Partial<RealtimeSyncMessage>;
+  if (typeof message.sourceId !== "string" || typeof message.timestamp !== "number") {
+    return false;
+  }
+
+  if (message.type === "folder-options") {
+    return Array.isArray(message.folderOptions) && message.folderOptions.every(isFolderOption);
+  }
+
+  if (message.type === "memo-tasks") {
+    return (
+      typeof message.folderId === "string" &&
+      Array.isArray(message.tasks) &&
+      message.tasks.every(isTask)
+    );
+  }
+
+  return false;
+};
+
+const parseMessage = (data: unknown) => {
+  if (typeof data === "string") {
+    try {
+      return JSON.parse(data) as unknown;
+    } catch {
+      return null;
+    }
+  }
+
+  return data;
+};
+
+const notifyListeners = (message: RealtimeSyncMessage) => {
+  if (message.sourceId === sourceId) {
+    return;
+  }
+
+  listeners.forEach((listener) => listener(message));
+};
+
+const sendSocketMessage = (message: RealtimeSyncMessage) => {
+  if (!socket) {
+    return;
+  }
+
+  if (socket.readyState === WebSocket.OPEN) {
+    socket.send(JSON.stringify(message));
+    return;
+  }
+
+  pendingSocketMessages.push(message);
+};
+
+const flushSocketMessages = () => {
+  if (!socket || socket.readyState !== WebSocket.OPEN) {
+    return;
+  }
+
+  while (pendingSocketMessages.length > 0) {
+    const message = pendingSocketMessages.shift();
+    if (message) {
+      socket.send(JSON.stringify(message));
+    }
+  }
+};
+
+const startRealtimeSync = () => {
+  if (started || typeof window === "undefined") {
+    return;
+  }
+
+  started = true;
+
+  if ("BroadcastChannel" in window) {
+    broadcastChannel = new BroadcastChannel(CHANNEL_NAME);
+    broadcastChannel.onmessage = (event: MessageEvent) => {
+      const message = parseMessage(event.data);
+      if (isRealtimeSyncMessage(message)) {
+        notifyListeners(message);
+      }
+    };
+  }
+
+  window.addEventListener("storage", (event) => {
+    if (event.key !== STORAGE_EVENT_KEY || !event.newValue) {
+      return;
+    }
+
+    const message = parseMessage(event.newValue);
+    if (isRealtimeSyncMessage(message)) {
+      notifyListeners(message);
+    }
+  });
+
+  if (syncWebSocketUrl) {
+    socket = new WebSocket(syncWebSocketUrl);
+    socket.addEventListener("open", flushSocketMessages);
+    socket.addEventListener("message", (event) => {
+      const message = parseMessage(event.data);
+      if (isRealtimeSyncMessage(message)) {
+        notifyListeners(message);
+      }
+    });
+    socket.addEventListener("close", () => {
+      socket = null;
+    });
+  }
+};
+
+export const publishRealtimeSync = (payload: RealtimeSyncPayload) => {
+  startRealtimeSync();
+
+  const message: RealtimeSyncMessage = {
+    ...payload,
+    sourceId,
+    timestamp: Date.now(),
+  };
+
+  broadcastChannel?.postMessage(message);
+  sendSocketMessage(message);
+
+  try {
+    localStorage.setItem(STORAGE_EVENT_KEY, JSON.stringify(message));
+  } catch (error) {
+    console.error("Failed to publish realtime sync message to localStorage", error);
+  }
+};
+
+export const subscribeRealtimeSync = (listener: RealtimeSyncListener) => {
+  startRealtimeSync();
+  listeners.add(listener);
+
+  return () => {
+    listeners.delete(listener);
+  };
+};

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,6 +3,7 @@
 interface ImportMetaEnv {
   readonly VITE_NOTION_SYNC_PAGE_ID?: string;
   readonly VITE_NOTION_SYNC_SECTION_PREFIX?: string;
+  readonly VITE_SYNC_WEBSOCKET_URL?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- Add a realtime sync transport that uses `VITE_SYNC_WEBSOCKET_URL` when configured.
- Keep same-browser multi-tab sync working without a server via `BroadcastChannel` and a `storage` event fallback.
- Sync folder list changes and memo/TODO task changes across connected views.
- Reset the selected folder to `All Folders` if a remote folder update removes the active folder.
- Document the WebSocket environment variable in `README.md`.

## Notes
- This adds the client-side WebSocket contract. The configured WebSocket endpoint is expected to broadcast received JSON messages to other connected clients.
- Without `VITE_SYNC_WEBSOCKET_URL`, cross-device sync is not active, but same-browser tab sync still works.

## Validation
- `npm run build`
- `npm run test`
- `npm run lint` (passes with existing generated `coverage/` warnings)

Closes #53