### PR TITLE
[codex] トースト位置と見た目を調整

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -347,7 +347,9 @@ function App() {
             },
           );
           const fetchedFiles = response.files || [];
-          logger.debug(`[fetchMusicFiles] Fetched ${fetchedFiles.length} files from ${folder.name}`);
+          logger.debug(
+            `[fetchMusicFiles] Fetched ${fetchedFiles.length} files from ${folder.name}`,
+          );
 
           // 取得したデータをキャッシュに保存（10分間有効）
           cacheMusicFiles(folder.id, fetchedFiles);
@@ -1056,57 +1058,59 @@ function App() {
         sx={{
           bottom: selectedFile
             ? {
-                xs: "calc(208px + env(safe-area-inset-bottom)) !important",
-                sm: "calc(176px + env(safe-area-inset-bottom)) !important",
+                xs: "calc(144px + env(safe-area-inset-bottom)) !important",
+                sm: "calc(128px + env(safe-area-inset-bottom)) !important",
               }
-            : "calc(24px + env(safe-area-inset-bottom)) !important",
+            : "calc(18px + env(safe-area-inset-bottom)) !important",
+          left: { sm: "24px !important" },
+          right: { sm: "auto !important" },
           zIndex: 1300,
         }}
         slotProps={{
           content: {
             sx: {
-              minWidth: "300px",
-              background:
-                "linear-gradient(135deg, rgba(255, 0, 110, 0.95), rgba(255, 77, 159, 0.95))",
-              backdropFilter: "blur(10px)",
-              border: "2px solid #ff006e",
-              borderRadius: "12px",
-              boxShadow: "0 0 30px rgba(255, 0, 110, 0.6), 0 8px 32px rgba(0, 0, 0, 0.4)",
+              minWidth: { xs: "min(92vw, 320px)", sm: "360px" },
+              maxWidth: { xs: "92vw", sm: "440px" },
+              background: "linear-gradient(135deg, rgba(22, 12, 38, 0.96), rgba(12, 38, 45, 0.94))",
+              backdropFilter: "blur(14px)",
+              border: "1px solid rgba(251, 248, 204, 0.24)",
+              borderRadius: "999px",
+              boxShadow: "0 10px 30px rgba(0, 0, 0, 0.36), 0 0 22px rgba(0, 245, 212, 0.18)",
               color: "#fff",
               fontWeight: 600,
-              fontSize: "1rem",
-              fontFamily: "Inter, sans-serif",
+              fontSize: "0.92rem",
+              px: 2,
+              py: 0.75,
               "& .MuiSnackbarContent-message": {
                 flex: 1,
-                textAlign: "center",
-                textShadow: "0 2px 10px rgba(0, 0, 0, 0.3)",
+                textAlign: "left",
+                textShadow: "none",
               },
               "& .MuiSnackbarContent-action": {
                 marginRight: 0,
-                paddingLeft: "16px",
+                paddingLeft: "12px",
                 "& .MuiButton-root": {
                   color: "#fbf8cc",
                   fontWeight: 700,
-                  textShadow: "0 0 10px rgba(251, 248, 204, 0.8)",
+                  borderRadius: "999px",
+                  textShadow: "none",
                   "&:hover": {
-                    background: "rgba(251, 248, 204, 0.1)",
-                    transform: "scale(1.05)",
+                    background: "rgba(251, 248, 204, 0.12)",
                   },
                   "&:focus": {
                     outline: "none",
                   },
-                  transition: "all 0.3s ease",
+                  transition: "background 0.2s ease",
                 },
                 "& .MuiIconButton-root": {
                   color: "#fff",
                   "&:hover": {
                     background: "rgba(255, 255, 255, 0.1)",
-                    transform: "rotate(90deg) scale(1.1)",
                   },
                   "&:focus": {
                     outline: "none",
                   },
-                  transition: "all 0.3s ease",
+                  transition: "background 0.2s ease",
                 },
               },
             },

--- a/src/components/MemoModal.tsx
+++ b/src/components/MemoModal.tsx
@@ -51,36 +51,42 @@ const getMemoStorageKey = (folderId: string) => `${LOCAL_STORAGE_KEYS.USER_MEMO_
 
 const memoSnackbarSx = {
   top: {
-    xs: "calc(88px + env(safe-area-inset-top)) !important",
-    sm: "calc(24px + env(safe-area-inset-top)) !important",
+    xs: "calc(76px + env(safe-area-inset-top)) !important",
+    sm: "calc(28px + env(safe-area-inset-top)) !important",
   },
-  right: { xs: "12px !important", sm: "24px !important" },
-  left: { xs: "12px !important", sm: "auto !important" },
+  right: {
+    xs: "14px !important",
+    sm: "calc((100vw - min(600px, 100vw - 64px)) / 2 + 20px) !important",
+  },
+  left: { xs: "14px !important", sm: "auto !important" },
   zIndex: 1400,
 };
 
 const getMemoToastSx = (mode: "success" | "error") => ({
   width: "100%",
-  minWidth: { xs: "auto", sm: "360px" },
+  minWidth: { xs: "auto", sm: "320px" },
+  maxWidth: { xs: "none", sm: "420px" },
   alignItems: "center",
-  borderRadius: "14px",
-  border: mode === "success" ? "2px solid #00f5d4" : "2px solid #ff006e",
+  borderRadius: "999px",
+  border:
+    mode === "success" ? "1px solid rgba(0, 245, 212, 0.46)" : "1px solid rgba(255, 0, 110, 0.5)",
   background:
     mode === "success"
-      ? "linear-gradient(135deg, rgba(0, 245, 212, 0.92), rgba(0, 180, 216, 0.92))"
-      : "linear-gradient(135deg, rgba(255, 0, 110, 0.95), rgba(255, 77, 159, 0.95))",
-  backdropFilter: "blur(12px)",
+      ? "linear-gradient(135deg, rgba(10, 52, 54, 0.96), rgba(0, 96, 110, 0.94))"
+      : "linear-gradient(135deg, rgba(74, 14, 42, 0.96), rgba(118, 22, 68, 0.94))",
+  backdropFilter: "blur(14px)",
   boxShadow:
     mode === "success"
-      ? "0 0 30px rgba(0, 245, 212, 0.45), 0 8px 32px rgba(0, 0, 0, 0.35)"
-      : "0 0 30px rgba(255, 0, 110, 0.55), 0 8px 32px rgba(0, 0, 0, 0.4)",
+      ? "0 10px 28px rgba(0, 0, 0, 0.32), 0 0 18px rgba(0, 245, 212, 0.2)"
+      : "0 10px 28px rgba(0, 0, 0, 0.36), 0 0 18px rgba(255, 0, 110, 0.22)",
   color: "#fff",
-  fontWeight: 700,
+  fontWeight: 600,
+  fontSize: "0.9rem",
   letterSpacing: "0.01em",
-  textShadow: "0 2px 10px rgba(0, 0, 0, 0.28)",
+  textShadow: "none",
   "& .MuiAlert-message": {
     width: "100%",
-    py: 0.25,
+    py: 0.1,
   },
   "& .MuiAlert-icon": {
     color: "#fbf8cc",


### PR DESCRIPTION
## 概要
- 共通トーストをボタン上に出さず、画面下寄りの控えめなピル型へ調整
- プレイヤー表示中の浮きすぎていたbottomオフセットを縮める
- メモモーダル内トーストをダイアログ右上に沿う位置へ調整し、ボタン列には重ならないようにする
- 強すぎるネオン枠、回転hover、中央寄せ文字を抑えて軽く見えるスタイルに変更

## 検証
- `npm run build`
- `npm run test`
- `npm run lint`（既存の `coverage/` warning のみ）