### PR TITLE
[codex] Accept Notion page URLs for sync config

### DIFF
--- a/api/notion/handler.ts
+++ b/api/notion/handler.ts
@@ -85,6 +85,21 @@ interface CreateNotionTodoResponseParams {
 
 const jsonResponse = <T>(status: number, body: T): JsonResponse<T> => ({ status, body });
 
+const normalizeNotionPageId = (value: string) => {
+  const trimmedValue = value.trim();
+  const compactId = trimmedValue.match(/[0-9a-fA-F]{32}/)?.[0];
+  if (compactId) {
+    return compactId;
+  }
+
+  const uuid = trimmedValue.match(
+    /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/,
+  )?.[0];
+  return uuid ? uuid.replace(/-/g, "") : trimmedValue;
+};
+
+const isNotionPageId = (value: string) => /^[0-9a-fA-F]{32}$/.test(value);
+
 const getPlainText = (richText: NotionRichTextItem[] = []) => {
   return richText
     .map((item) => item.plain_text ?? "")
@@ -424,7 +439,9 @@ export const createNotionTodoResponse = async ({
     return jsonResponse(500, { error: "NOTION_API_KEY is not configured" });
   }
 
-  const pageId = (method === "GET" ? searchParams.get("pageId") : body?.pageId)?.trim();
+  const pageId = normalizeNotionPageId(
+    (method === "GET" ? searchParams.get("pageId") : body?.pageId)?.trim() ?? "",
+  );
   const sectionTitle = (
     method === "GET" ? searchParams.get("sectionTitle") : body?.sectionTitle
   )?.trim();
@@ -432,6 +449,12 @@ export const createNotionTodoResponse = async ({
 
   if (!pageId || !sectionTitle) {
     return jsonResponse(400, { error: "pageId and sectionTitle are required" });
+  }
+
+  if (!isNotionPageId(pageId)) {
+    return jsonResponse(400, {
+      error: "pageId must be a Notion page ID or a Notion page URL",
+    });
   }
 
   try {

--- a/src/utils/notionTodo.test.ts
+++ b/src/utils/notionTodo.test.ts
@@ -1,4 +1,4 @@
-import { buildNotionSyncSectionTitle } from "./notionTodo";
+import { buildNotionSyncSectionTitle, normalizeNotionPageId } from "./notionTodo";
 
 describe("notionTodo utilities", () => {
   it("uses a stable app-managed toggle title", () => {
@@ -7,5 +7,17 @@ describe("notionTodo utilities", () => {
 
   it("does not include the folder name in the toggle title", () => {
     expect(buildNotionSyncSectionTitle("   ")).toBe("App TODO");
+  });
+
+  it("extracts a Notion page ID from a copied Notion URL", () => {
+    expect(
+      normalizeNotionPageId("https://www.notion.so/TODO-35122d999b12801c93fff4245a8531b0?source=copy_link"),
+    ).toBe("35122d999b12801c93fff4245a8531b0");
+  });
+
+  it("normalizes hyphenated Notion page IDs", () => {
+    expect(normalizeNotionPageId("b8265b1f-76fe-4f13-9025-c06ea102a459")).toBe(
+      "b8265b1f76fe4f139025c06ea102a459",
+    );
   });
 });

--- a/src/utils/notionTodo.ts
+++ b/src/utils/notionTodo.ts
@@ -8,7 +8,22 @@ interface NotionTodoResponse {
   error?: string;
 }
 
-const notionSyncPageId = import.meta.env.VITE_NOTION_SYNC_PAGE_ID?.trim() ?? "";
+const rawNotionSyncPageId = import.meta.env.VITE_NOTION_SYNC_PAGE_ID?.trim() ?? "";
+
+export const normalizeNotionPageId = (value: string) => {
+  const trimmedValue = value.trim();
+  const compactId = trimmedValue.match(/[0-9a-fA-F]{32}/)?.[0];
+  if (compactId) {
+    return compactId;
+  }
+
+  const uuid = trimmedValue.match(
+    /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/,
+  )?.[0];
+  return uuid ? uuid.replace(/-/g, "") : trimmedValue;
+};
+
+const notionSyncPageId = normalizeNotionPageId(rawNotionSyncPageId);
 
 const getSectionPrefix = () => {
   return import.meta.env.VITE_NOTION_SYNC_SECTION_PREFIX?.trim() || NOTION_SYNC_SECTION_PREFIX;


### PR DESCRIPTION
## Summary
- Normalize Notion page IDs from raw IDs, hyphenated IDs, and copied Notion page URLs.
- Apply normalization on both the frontend sync config and server API input.
- Return a clearer API error when pageId is not a Notion page ID or URL.

## Validation
- `npm run build`
- `npm run test -- src/utils/notionTodo.test.ts src/components/MemoModal.test.tsx`
- Local API POST with `pageId` set to a copied Notion URL returned `{"updated":true,"created":false}`.