### PR TITLE
[codex] Use absolute Notion sync API URLs

### DIFF
--- a/src/utils/notionTodo.ts
+++ b/src/utils/notionTodo.ts
@@ -39,6 +39,14 @@ const parseResponse = async (response: Response) => {
   return data;
 };
 
+const buildNotionApiUrl = (path: string) => {
+  if (typeof window === "undefined") {
+    return path;
+  }
+
+  return new URL(path, window.location.origin).toString();
+};
+
 export const isNotionSyncConfigured = () => notionSyncPageId !== "";
 
 export const buildNotionSyncSectionTitle = (_folderName: string) => {
@@ -56,7 +64,16 @@ export const loadTasksFromNotion = async (folderName: string) => {
     sectionTitle: buildNotionSyncSectionTitle(folderName),
   });
 
-  const response = await fetch(`/api/notion/todo?${params.toString()}`);
+  let response: Response;
+  try {
+    response = await fetch(buildNotionApiUrl(`/api/notion/todo?${params.toString()}`));
+  } catch (error) {
+    throw new Error(
+      error instanceof Error
+        ? `Notion sync request could not be sent: ${error.message}`
+        : "Notion sync request could not be sent",
+    );
+  }
   const data = await parseResponse(response);
 
   return {
@@ -70,21 +87,30 @@ export const saveTasksToNotion = async (folderName: string, tasks: Task[]) => {
     throw new Error("Notion sync is not configured");
   }
 
-  const response = await fetch("/api/notion/todo", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      pageId: notionSyncPageId,
-      folderName,
-      sectionTitle: buildNotionSyncSectionTitle(folderName),
-      tasks: tasks.map((task) => ({
-        text: task.text,
-        completed: task.completed,
-      })),
-    }),
-  });
+  let response: Response;
+  try {
+    response = await fetch(buildNotionApiUrl("/api/notion/todo"), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        pageId: notionSyncPageId,
+        folderName,
+        sectionTitle: buildNotionSyncSectionTitle(folderName),
+        tasks: tasks.map((task) => ({
+          text: task.text,
+          completed: task.completed,
+        })),
+      }),
+    });
+  } catch (error) {
+    throw new Error(
+      error instanceof Error
+        ? `Notion sync request could not be sent: ${error.message}`
+        : "Notion sync request could not be sent",
+    );
+  }
 
   await parseResponse(response);
 };


### PR DESCRIPTION
## Summary
- Build Notion sync API requests from `window.location.origin` instead of bare relative paths.
- Wrap fetch construction errors with clearer Notion sync request errors.

## Validation
- `npm run build`
- `npm run test -- src/utils/notionTodo.test.ts src/components/MemoModal.test.tsx`
- Local API POST to `/api/notion/todo` with a copied Notion URL returned `{"updated":true,"created":false}`.