### PR TITLE
fix: モバイル未ログイン画面のヘッダー余白を調整

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -494,7 +494,12 @@ function App() {
     <Box sx={{ display: "flex", flexDirection: "column", height: "100dvh" }}>
       <CssBaseline />
       {/* アプリケーションのヘッダー部分 */}
-      <AppBar position="static">
+      <AppBar
+        position="static"
+        sx={{
+          mb: accessToken ? 0 : { xs: 1.5, sm: 0 },
+        }}
+      >
         <Toolbar sx={{ gap: 2, mt: 0, mb: 0, pt: "env(safe-area-inset-top)" }}>
           <MusicNoteIcon sx={{ mr: 2 }} />
           <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>


### PR DESCRIPTION
## 概要
- iPhone PWA などのモバイル表示で、未ログイン画面のヘッダー直下が詰まって見える問題を調整
- ログイン後の画面では既存のヘッダー余白を維持

## 変更内容
- 未ログイン時のみ、モバイル幅の AppBar 下部に余白を追加
- ログイン済みの場合は従来どおり余白なしにして、リスト画面の密度を変えないように調整

## テスト計画
- [x] Lint通過（既存の coverage 配下 warning のみ）
- [x] ビルド成功

🤖 Generated with [Codex CLI](https://openai.com/codex)